### PR TITLE
Tea served by Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,30 @@
+# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+
+tasks:
+  - init: |
+      # runs during prebuild
+      (
+        set -e
+
+        # install deno
+        curl -fsSL https://deno.land/install.sh | sh
+      )
+    command: |
+      # runs during startup
+      (
+        set -e
+
+        # compile ./tea
+        deno compile \
+          --allow-read \
+          --allow-write \
+          --allow-net \
+          --allow-run \
+          --allow-env \
+          --unstable \
+          --import-map="import-map.json" \
+          --output "./tea" \
+          "src/app.ts"
+
+        echo "./tea is hot"
+      )

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,8 +6,9 @@ tasks:
       (
         set -e
 
-        # install deno
-        curl -fsSL https://deno.land/install.sh | sh
+        # install `deno` for bootstrap into workspace dir
+        # https://www.gitpod.io/docs/configure/projects/prebuilds#workspace-directory-only
+        curl -fsSL https://deno.land/install.sh | DENO_INSTALL=.deno sh
       )
     command: |
       # runs during startup
@@ -15,7 +16,7 @@ tasks:
         set -e
 
         # compile ./tea
-        deno compile \
+        .deno/bin/deno compile \
           --allow-read \
           --allow-write \
           --allow-net \


### PR DESCRIPTION
Get `./tea` with a single click.

**Click Me:** https://gitpod.io/#https://github.com/teaxyz/cli/pull/127

This downloads `deno` for compiling `tea` into `.deno/` in current dir, because Gitpod doesn't persist $HOME when initializing.
```
Deno was installed successfully to .deno/bin/deno
```
Then it compiles `./tea` using README instructons, but doesn't install it.
```
Download ⠋ https://deno.land/x/rimbu@0.12.3/sorted/map-custom/implementation/immutable.tsCheck file:///workspace/teaxyz-cli/src/app.ts
Download ⠸ https://deno.land/x/rimbu@0.12.3/sorted/map-custom/implementation/immutable.ts                                 Compile file:///workspace/teaxyz-cli/src/app.ts
Emit ./tea
./tea is hot
```

Running `./tea` without arguments fails for some reason.
```
$ ./tea
error: Uncaught (in promise) "not-found:deno.land"
```
But help works fine.
```
$ ./tea --help
usage:
  tea [-xdX] [flags] [+package~x.y] [file|URL|target|cmd|interpreter] -- [arg…]
...
```