### PR TITLE
Store etag So Downloads Use Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,7 +802,7 @@ deno test \
  --allow-env=SRCROOT,GITHUB_TOKEN,TMPDIR,TEA_PREFIX,MUGGLE,MAGIC,JSON,NUMPTY \
  --allow-run \
  --import-map=$SRCROOT/import-map.json \
- --allow-write \
+ --allow-write=$TEA_PREFIX/tea.xyz/var,$TMPDIR \
  --unstable \
  "$SRCROOT"/tests/**/*.test.ts
 ```

--- a/README.md
+++ b/README.md
@@ -786,10 +786,10 @@ export TMPDIR=${TMPDIR:-/tmp}
 deno test \
  --allow-net \
  --allow-read \
- --allow-env=SRCROOT,GITHUB_TOKEN,TMPDIR,TEA_PREFIX \
+ --allow-env=SRCROOT,GITHUB_TOKEN,TMPDIR,TEA_PREFIX,MUGGLE,MAGIC,JSON,NUMPTY \
  --allow-run \
  --import-map=$SRCROOT/import-map.json \
- --allow-write="$TMPDIR" \
+ --allow-write \
  --unstable \
  "$SRCROOT"/tests/**/*.test.ts
 ```

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -48,9 +48,9 @@ async function internal<T>({ src, dst, headers, ephemeral, logger }: DownloadOpt
   if (!ephemeral && dst.isReadableFile()) {
     
     headers ??= {}
-    if(etag_entry().isFile()){
+    if (etag_entry().isFile()) {
       headers["If-None-Match"] = await etag_entry().read()
-    } else if(mtime_entry().isFile()){
+    } else if (mtime_entry().isFile()) {
       headers["If-Modified-Since"] = await mtime_entry().read()
     }
 

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -48,13 +48,10 @@ async function internal<T>({ src, dst, headers, ephemeral, logger }: DownloadOpt
   if (!ephemeral && dst.isReadableFile()) {
     
     headers ??= {}
-    if(mtime_entry().isFile() && etag_entry().isFile()){
-      headers["If-Modified-Since"] = await mtime_entry().read()
+    if(etag_entry().isFile()){
       headers["If-None-Match"] = await etag_entry().read()
     } else if(mtime_entry().isFile()){
       headers["If-Modified-Since"] = await mtime_entry().read()
-    } else if(etag_entry().isFile()){
-      headers["If-None-Match"] = await etag_entry().read()
     }
 
     logger.replace(teal('querying'))

--- a/tests/unit/cache.test.ts
+++ b/tests/unit/cache.test.ts
@@ -5,7 +5,7 @@ import { sandbox } from "../utils.ts"
 Deno.test("etag-mtime-check",async () => {
   await sandbox(async tmpdir => {
     const src = new URL("https://dist.tea.xyz/ijg.org/versions.txt")
-    const dst = await useDownload().download({src, dst: tmpdir.join("test.tar.xz")})
+    await useDownload().download({src, dst: tmpdir.join("test.tar.xz")})
 
     const mtimePath = await useDownload().hash_key(src).join("mtime")
     const etagPath = await useDownload().hash_key(src).join("etag")

--- a/tests/unit/cache.test.ts
+++ b/tests/unit/cache.test.ts
@@ -5,7 +5,7 @@ import { sandbox } from "../utils.ts"
 Deno.test("etag-mtime-check",async () => {
   await sandbox(async tmpdir => {
     const src = new URL("https://dist.tea.xyz/ijg.org/versions.txt")
-    await useDownload().download({src, dst: tmpdir.join("version.txt")})
+    await useDownload().download({src, dst: tmpdir.join("versions.txt")})
 
     const mtimePath = await useDownload().hash_key(src).join("mtime")
     const etagPath = await useDownload().hash_key(src).join("etag")

--- a/tests/unit/cache.test.ts
+++ b/tests/unit/cache.test.ts
@@ -1,0 +1,24 @@
+import { assert } from "deno/testing/asserts.ts"
+import { useDownload } from "hooks"
+import { sandbox } from "../utils.ts"
+
+Deno.test("etag-mtime-check",async () => {
+  await sandbox(async tmpdir => {
+    const src = new URL("https://dist.tea.xyz/deno.land/darwin/aarch64/v1.27.1.tar.xz")
+    const dst = await useDownload().download({src, dst: tmpdir.join("test.tar.xz")})
+
+    const mtimePath = await useDownload().hash_key(src).join("mtime")
+    const etagPath = await useDownload().hash_key(src).join("etag")
+
+    const mtime = await mtimePath.read()
+    const etag = await etagPath.read()
+    
+    const rsp = await fetch(src, {})
+    const mtimeA = rsp.headers.get("Last-Modified")
+    const etagA = rsp.headers.get("etag")
+
+    assert(mtimeA === mtime)
+    assert(etagA === etag)
+    await rsp.body?.cancel()
+  })
+})

--- a/tests/unit/cache.test.ts
+++ b/tests/unit/cache.test.ts
@@ -4,7 +4,7 @@ import { sandbox } from "../utils.ts"
 
 Deno.test("etag-mtime-check",async () => {
   await sandbox(async tmpdir => {
-    const src = new URL("https://dist.tea.xyz/deno.land/darwin/aarch64/v1.27.1.tar.xz")
+    const src = new URL("https://dist.tea.xyz/ijg.org/versions.txt")
     const dst = await useDownload().download({src, dst: tmpdir.join("test.tar.xz")})
 
     const mtimePath = await useDownload().hash_key(src).join("mtime")

--- a/tests/unit/cache.test.ts
+++ b/tests/unit/cache.test.ts
@@ -5,7 +5,7 @@ import { sandbox } from "../utils.ts"
 Deno.test("etag-mtime-check",async () => {
   await sandbox(async tmpdir => {
     const src = new URL("https://dist.tea.xyz/ijg.org/versions.txt")
-    await useDownload().download({src, dst: tmpdir.join("test.tar.xz")})
+    await useDownload().download({src, dst: tmpdir.join("version.txt")})
 
     const mtimePath = await useDownload().hash_key(src).join("mtime")
     const etagPath = await useDownload().hash_key(src).join("etag")


### PR DESCRIPTION
Storing Etag received from `fetch` API parallel to mtime file and passing this header to `If-None-Match`. 
Fixing https://github.com/teaxyz/cli/issues/85