### PR TITLE
support bash for tea shell

### DIFF
--- a/src/app.exec.ts
+++ b/src/app.exec.ts
@@ -230,6 +230,12 @@ async function repl(installations: Installation[], env: Record<string, string>) 
   //TODO other shells pls #help-wanted
 
   switch (basename(shell)) {
+  case 'bash':
+    cmd.splice(1, 0, '--norc', '--noprofile') // longopts must precede shortopts
+    // fall through
+  case 'sh':
+    env['PS1'] = "\\[\\033[38;5;86m\\]tea\\[\\033[0m\\] %~ "
+    break
   case 'zsh':
     env['PS1'] = "%F{086}tea%F{reset} %~ "
     cmd.push('--no-rcs', '--no-globalrcs')

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -46,7 +46,7 @@ async function internal<T>({ src, dst, headers, ephemeral, logger }: DownloadOpt
   if (src.protocol === "file:") throw new Error()
 
   if (!ephemeral && dst.isReadableFile()) {
-    
+
     headers ??= {}
     if (etag_entry().isFile()) {
       headers["If-None-Match"] = await etag_entry().read()
@@ -85,9 +85,9 @@ async function internal<T>({ src, dst, headers, ephemeral, logger }: DownloadOpt
       await body(reader, f, sz)
 
       const text = rsp.headers.get("Last-Modified")
-      const etag = rsp.headers.get("etag")
+      const etag = rsp.headers.get("ETag")
 
-      if (text) mtime_entry().write({ text, force: true })
+      if (text) mtime_entry().write({text, force: true})
       if (etag) etag_entry().write({text: etag, force: true})
 
     } finally {


### PR DESCRIPTION
Add a few cases to support `bash` and `sh`. We can't pass `--norc` and `--noprofile` to `sh` since those are GNU-isms.
