### PR TITLE
fix(dump): update fish command-not-found

### DIFF
--- a/src/app.dump.ts
+++ b/src/app.dump.ts
@@ -170,13 +170,13 @@ export default async function dump(args: Args) {
       break
     case 'fish':
       rv = undent`
-        function command_not_found_handler
-          switch "$argv[0]"`
+        function fish_command_not_found
+          switch "$argv[1]"\n\n`;
       for (const uninstalled of pending) {
         const exes = await pantry.getProvides(uninstalled)
         if (exes.length) {
           const cmds = exes.join(" ")
-          rv += `    case ${cmds}; tea '+${pkg.str(uninstalled)}' "$argv"\n`
+          rv += `    case ${cmds}; tea '+${pkg.str(uninstalled)}' $argv\n`
         }
       }
       rv += "  end\nend"
@@ -193,7 +193,7 @@ export default async function dump(args: Args) {
         await print("if typeset -f command_not_found_handle >/dev/null; then unset -f command_not_found_handle; fi")
         break
       case 'fish':
-        await print("if functions --query command_not_found_handler >/dev/null; functions --erase command_not_found_handler; end")
+        await print("if functions --query fish_command_not_found; functions --erase fish_command_not_found; end")
         break
     }
   }

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -46,7 +46,7 @@ async function internal<T>({ src, dst, headers, ephemeral, logger }: DownloadOpt
   if (src.protocol === "file:") throw new Error()
 
   if (!ephemeral && dst.isReadableFile()) {
-    
+
     headers ??= {}
     if (etag_entry().isFile()) {
       headers["If-None-Match"] = await etag_entry().read()
@@ -85,9 +85,9 @@ async function internal<T>({ src, dst, headers, ephemeral, logger }: DownloadOpt
       await body(reader, f, sz)
 
       const text = rsp.headers.get("Last-Modified")
-      const etag = rsp.headers.get("etag")
+      const etag = rsp.headers.get("ETag")
 
-      if (text) mtime_entry().write({ text, force: true })
+      if (text) mtime_entry().write({text, force: true})
       if (etag) etag_entry().write({text: etag, force: true})
 
     } finally {


### PR DESCRIPTION
Thanks for tea, loving it so far! Here's a few quick fixes for fish I encountered:

- Command not found function is called [fish_command_not_found](https://fishshell.com/docs/current/cmds/fish_command_not_found.html)
- Lists are [1-indexed](https://fishshell.com/docs/current/language.html?highlight=List+indices+start#lists)
- Unquote `"$argv"` to prevent `tea` from intrepreting all arguments as the command (currently fails with `tea: command not found: [ "node --version" ]`)

Also added an extra newline for formatting.

Before:

```fish
function command_not_found_handler
  switch "$argv[0]"    case wget; tea '+gnu.org/wget' "$argv"
    case node; tea '+nodejs.org' "$argv"
  end
end
```

After:

```fish
function fish_command_not_found
  switch "$argv[1]"
    case wget; tea '+gnu.org/wget' $argv
    case node; tea '+nodejs.org' $argv
  end
end
```
