### PR TITLE
Tea foo regex change

### DIFF
--- a/src/hooks/useFlags.ts
+++ b/src/hooks/useFlags.ts
@@ -68,7 +68,7 @@ export function useArgs(args: string[], arg0: string): [Args, Flags & Convenienc
   if (/(.+\/|^)tea_([^\/]+)$/.test(arg0)) {
     args = [...args]  // args is usually the immutable `Deno.args`
     //TODO apply muggle mode
-    const match = arg0.match(/tea_(.+)$/)!
+    const match = arg0.match(/tea_([^\/]+)$/)!
     args.unshift("-X", match[1])
   }
 

--- a/src/hooks/useFlags.ts
+++ b/src/hooks/useFlags.ts
@@ -65,7 +65,7 @@ export type Args = {
 export function useArgs(args: string[], arg0: string): [Args, Flags & ConvenienceFlags] {
   if (flags) throw new Error("contract-violated")
 
-  if (/(.+\/|^)tea_(.+)$/.test(arg0)) {
+  if (/(.+\/|^)tea_([^\/]+)$/.test(arg0)) {
     args = [...args]  // args is usually the immutable `Deno.args`
     //TODO apply muggle mode
     const match = arg0.match(/tea_(.+)$/)!


### PR DESCRIPTION
This is related to https://github.com/teaxyz/cli/issues/167. I'm trying to decide how to add another check and I'm pretty sure that the regex needs to be modified for the tea_foo test. Without this change, match[1] would be "path/tea" if the path were "/opt/tea_path/tea". I don't know why anyone would do that, but it's possible.

Also, this pull request is my way of getting my feet wet.