### PR TITLE
Adds tea.yml support. closes #201

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,0 +1,3 @@
+{
+  "importMap": "import-map.json"
+}

--- a/import-map.json
+++ b/import-map.json
@@ -6,6 +6,7 @@
     "hooks/": "./src/hooks/",
     "prefab": "./src/prefab/index.ts",
     "prefab/": "./src/prefab/",
+    "common/": "./src/common/",
     "deno/": "https://deno.land/std@0.156.0/",
     "semver": "./src/utils/semver.ts",
     "utils": "./src/utils/index.ts",

--- a/src/app.help.ts
+++ b/src/app.help.ts
@@ -14,6 +14,7 @@ export default async function help() {
   if (!verbose) {
     //        10|       20|       30|       40|       50|       60|       70| |     80|
     await print(undent`
+      // TODO JL REMOVE !!!!!! DEV MODE
       usage:
         tea [-xdX] [flags] [+package~x.y] [file|URL|target|cmd|interpreter] -- [arg…]
 

--- a/src/app.help.ts
+++ b/src/app.help.ts
@@ -14,7 +14,6 @@ export default async function help() {
   if (!verbose) {
     //        10|       20|       30|       40|       50|       60|       70| |     80|
     await print(undent`
-      // TODO JL REMOVE !!!!!! DEV MODE
       usage:
         tea [-xdX] [flags] [+package~x.y] [file|URL|target|cmd|interpreter] -- [arg…]
 

--- a/src/common/requirementsCandidate.ts
+++ b/src/common/requirementsCandidate.ts
@@ -1,0 +1,47 @@
+export const markdown_extensions = [
+  "md",
+  "mkd",
+  "mdwn",
+  "mdown",
+  "mdtxt",
+  "mdtext",
+  "markdown",
+  "text",
+  "md.txt",
+] as const;
+type MarkdownExtension = typeof markdown_extensions[number];
+
+const yaml_extensions = ["yml", "yaml"];
+type YamlExtension = typeof yaml_extensions[number];
+
+export type RequirementsCandidate =
+  | "package.json"
+  | `tea.${YamlExtension}`
+  | `README.${MarkdownExtension}`;
+
+export const enum RequirementsCandidateType {
+  PACKAGE_JSON,
+  TEA_YAML,
+  README,
+}
+
+export const candidateType = (
+  candiate: RequirementsCandidate
+): RequirementsCandidateType => {
+  switch (true) {
+    case candiate === "package.json":
+      return RequirementsCandidateType.PACKAGE_JSON;
+    case /^tea\.ya?ml$/.test(candiate):
+      return RequirementsCandidateType.TEA_YAML;
+    default:
+      return RequirementsCandidateType.README;
+  }
+};
+
+export const buildRequirementsCandidates = (): RequirementsCandidate[] => {
+  const markdownFiles = markdown_extensions.map(
+    (mde) => `README.${mde}` as const
+  );
+  const yamlFiles = yaml_extensions.map((ye) => `tea.${ye}` as const);
+  return ["package.json", ...yamlFiles, ...markdownFiles];
+};

--- a/src/hooks/useRequirementsFile.ts
+++ b/src/hooks/useRequirementsFile.ts
@@ -24,19 +24,14 @@ export default function useRequirementsFile(file: Path): Promise<RequirementsFil
   }
 }
 
-//TODO is this the config version or the project version?
-//TODO what version should this be??
-const CURRENT_CONFIG_VERSION = "1.0.0" as const
-
 type configFile = {
-  version: typeof CURRENT_CONFIG_VERSION,
+  version: string,
   tea: {
     dependencies: Record<string, string>
   }
 }
 
 function config_file_is_valid(config: unknown, errorString: string): config is configFile {
-  console.log("checking config file:", config)
   //TODO should we check for version in here?
   const presumedConfig = config as configFile
   if(!presumedConfig) return false
@@ -46,7 +41,6 @@ function config_file_is_valid(config: unknown, errorString: string): config is c
   if(!presumedConfig.tea.dependencies) return false
   if(!isPlainObject(presumedConfig.tea.dependencies))
     throw Error(`Bad ${errorString}, key: \`tea.dependencies\` is not a valid object.`)
-  console.log("config is valid")
   return true
 }
 
@@ -62,7 +56,7 @@ async function config_file(path: Path, candidateType: RequirementsCandidateType)
   const config = await parse_config(path, candidateType)
   if(!config) return undefined
   const requirements = parsePackageRequirements(config.tea.dependencies)
-  const version = new SemVer(config.version)
+  const version = config.version ? new SemVer(config.version) : undefined
   return { file: path, pkgs: requirements ?? [], version }
 }
 
@@ -73,7 +67,6 @@ function parsePackageRequirements(input: PlainObject): PackageRequirement[] {
     if (included.has(project)) throw new Error(`duplicate-constraint:${project}`)
     const rq: PackageRequirement = { project, constraint: new semver.Range(v.toString()) }
     rv.push(rq)
-    console.verbose({ found: rq })
   }
   return rv
 }

--- a/src/hooks/useRequirementsFile.ts
+++ b/src/hooks/useRequirementsFile.ts
@@ -32,9 +32,11 @@ type configFile = {
 }
 
 function config_file_is_valid(config: unknown, errorString: string): config is configFile {
-  //TODO should we check for version in here?
   const presumedConfig = config as configFile
   if(!presumedConfig) return false
+  //TODO swap string check for a semver regex test
+  if(presumedConfig.version && typeof presumedConfig.version !== 'string')
+    throw Error(`Bad ${errorString}, key \`version\` is not a valid string`)
   if(!presumedConfig.tea) return false
   if(!isPlainObject(presumedConfig.tea))
     throw Error(`Bad ${errorString}, key: \`tea\` is not a valid object.`)

--- a/src/hooks/useRequirementsFile.ts
+++ b/src/hooks/useRequirementsFile.ts
@@ -18,9 +18,11 @@ export default function useRequirementsFile(file: Path): Promise<RequirementsFil
   const cType = candidateType(file.basename() as RequirementsCandidate)
   switch(cType) {
     case RequirementsCandidateType.TEA_YAML: 
-    case RequirementsCandidateType.PACKAGE_JSON: return config_file(file, cType)
+    case RequirementsCandidateType.PACKAGE_JSON:
+      return config_file(file, cType)
     case RequirementsCandidateType.README:    
-    default:  return markdown(file)
+    default:
+      return markdown(file)
   }
 }
 
@@ -31,12 +33,18 @@ type configFile = {
   }
 }
 
+function is_valid_semver_string(ver: string) {
+  return /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/.test(ver)
+}
+
 function config_file_is_valid(config: unknown, errorString: string): config is configFile {
   const presumedConfig = config as configFile
   if(!presumedConfig) return false
-  //TODO swap string check for a semver regex test
-  if(presumedConfig.version && typeof presumedConfig.version !== 'string')
-    throw Error(`Bad ${errorString}, key \`version\` is not a valid string`)
+  if(
+    presumedConfig.version &&
+    typeof presumedConfig.version !== 'string' &&
+    is_valid_semver_string(presumedConfig.version)
+  ) throw Error(`Bad ${errorString}, key \`version\` is not a valid semver string`)
   if(!presumedConfig.tea) return false
   if(!isPlainObject(presumedConfig.tea))
     throw Error(`Bad ${errorString}, key: \`tea\` is not a valid object.`)

--- a/src/hooks/useVirtualEnv.ts
+++ b/src/hooks/useVirtualEnv.ts
@@ -43,22 +43,20 @@ export default async function useVirtualEnv(opts?: { cwd: Path }): Promise<Virtu
   const files: RequirementsFile[] = await (async () => {
     const rv: RequirementsFile[] = []
     const basenames = buildRequirementsCandidates()
-    console.log("VALID FILES " + basenames + " //////")
     for (const basename of basenames) {
       const path = srcroot.join(basename).isFile()
       if (!path) continue
-        console.log("found:", path)
       const rf = await useRequirementsFile(path)
       if (rf) rv.push(rf)
     }
     return rv
   })()
 
+
   if (files.length < 1) throw new TeaError("not-found: virtual-env", ctx)
 
   //TODO would it be better to test the readme for a deps table if it exists?
   const { file, version } = files.find(x => /^tea.ya?ml$/.test(x.file.basename())) ?? files.find(x => x.file.basename() == "README.md") ?? files[0]
-  console.log("FILE " + file + "//////////")
   const pkgs = files.flatMap(x => x.pkgs)
 
   //TODO magic deps should not conflict with requirements files deps


### PR DESCRIPTION
*closes #201*
### What
This PR adds support for a `tea.yml` and `.github/tea.yml` config file to drive magic functionality. The schema for the yml file copies that of the existing package.json support. 

Eg.
- tea.yml
```yml
version: 1.0.1
tea:
  dependencies:
    nodejs.org: 19
    go.dev: 1.19
```
- package.json
```json
{
  "version": "1.0.1",
  "dependencies": {
    "nodejs.org": 19,
    "go.dev": "1.19"
  }
}
```

### TODO:
- [x] Add tea.yml loader
- [x] Refactor json logic to support yaml and share schema
- [x] Move common requirements logic/types to `sr/common/` directory 
- [x] Investigate existing behavior whereby a package.json (and now a tea.yml) will prevent markdown scripts from running.
   - I would consider this out of the scope of this ticket. I'll create an issue.
   running `touch package.json` in the root of the cli repo will break commands such as `tea install-self`
- [x] Understand what the version in the config is for
   - It's the version of the project using tea, semver string. got it!
- [x] Remove junky console logs
- [ ] Update docs
- [ ] .github/tea.yml support
- [ ] UX - Do we want to let the user know which file has been loaded? 
- [ ] fix failing tests
- [ ] add new tests?
