### PR TITLE
Add runtime environment variables configuration

### DIFF
--- a/src/app.dump.ts
+++ b/src/app.dump.ts
@@ -125,7 +125,7 @@ export default async function dump(args: Args) {
     await print(unsetEnv("VERSION"))
   }
 
-  const env = useShellEnv({installations, pending, pristine: true})
+  const env = await useShellEnv({installations, pending, pristine: true})
 
   //TODO if PATH is the same as the current PATH maybe don't do it
   // though that makes the behavior of --env --dump very specific

--- a/src/app.exec.ts
+++ b/src/app.exec.ts
@@ -383,6 +383,6 @@ async function install(pkgs: PackageSpecification[]): Promise<{ env: Record<stri
     await link(install)
     installed.push(install)
   }
-  const env = useShellEnv({ installations: installed })
+  const env = await useShellEnv({ installations: installed })
   return { env: flatten(env), installed }
 }

--- a/src/hooks/usePantry.ts
+++ b/src/hooks/usePantry.ts
@@ -31,6 +31,7 @@ export default function usePantry() {
     getProvides,
     getYAML,
     getInterpreter,
+    getRuntimeEnvironment,
     resolve,
     ls,
     prefix
@@ -183,6 +184,11 @@ const getInterpreter = async (_extension: string): Promise<Interpreter | undefin
     }
   }
   return undefined
+}
+
+const getRuntimeEnvironment = async (pkg: {project: string}): Promise<Record<string, string>> => {
+  const yml = await entry(pkg).yml()
+  return yml["runtime"]?.["env"] ?? {}
 }
 
 // deno-lint-ignore no-explicit-any


### PR DESCRIPTION
Allow specifying env vars to be set at runtime in pantry configs.

Example:

```yaml
runtime:
  env:
    DENO_NO_UPDATE_CHECK: "true"
```

Updates #26