### PR TITLE
Use sandbox-exec on macOS to disable writes to TEA_PREFIX

### DIFF
--- a/src/app.exec.ts
+++ b/src/app.exec.ts
@@ -112,7 +112,7 @@ async function exec(ass: RV1, pkgs: PackageSpecification[], opts: {env: boolean}
 
     const cmd = [arg0, ...ass.args]
 
-    await run({cmd, env, useSandboxExec: true})
+    await run({cmd, env, useSandboxExec: false})
 
   } break
 
@@ -168,7 +168,7 @@ async function exec(ass: RV1, pkgs: PackageSpecification[], opts: {env: boolean}
     supp(env, blueprint)
     if (yaml?.env) Object.assign(env, yaml.env)  // explicit YAML-FM env takes precedence
 
-    await run({ cmd, env, useSandboxExec: true })
+    await run({ cmd, env, useSandboxExec: false })
 
   } break
 
@@ -182,7 +182,7 @@ async function exec(ass: RV1, pkgs: PackageSpecification[], opts: {env: boolean}
     }
     const { env } = await install(pkgs)
     supp(env, blueprint)
-    await run({ cmd: ass.args, env, useSandboxExec: true })
+    await run({ cmd: ass.args, env, useSandboxExec: false })
   }}
 }
 

--- a/src/app.exec.ts
+++ b/src/app.exec.ts
@@ -112,7 +112,7 @@ async function exec(ass: RV1, pkgs: PackageSpecification[], opts: {env: boolean}
 
     const cmd = [arg0, ...ass.args]
 
-    await run({cmd, env})
+    await run({cmd, env, useSandboxExec: true})
 
   } break
 
@@ -168,7 +168,7 @@ async function exec(ass: RV1, pkgs: PackageSpecification[], opts: {env: boolean}
     supp(env, blueprint)
     if (yaml?.env) Object.assign(env, yaml.env)  // explicit YAML-FM env takes precedence
 
-    await run({ cmd, env })
+    await run({ cmd, env, useSandboxExec: true })
 
   } break
 
@@ -182,7 +182,7 @@ async function exec(ass: RV1, pkgs: PackageSpecification[], opts: {env: boolean}
     }
     const { env } = await install(pkgs)
     supp(env, blueprint)
-    await run({ cmd: ass.args, env })
+    await run({ cmd: ass.args, env, useSandboxExec: true })
   }}
 }
 
@@ -316,7 +316,7 @@ async function repl(installations: Installation[], env: Record<string, string>) 
   }
 
   try {
-    await run({ cmd, env })
+    await run({ cmd, env, useSandboxExec: true })
   } catch (err) {
     if (err instanceof RunError) {
       Deno.exit(err.code)

--- a/src/utils/sandbox.ts
+++ b/src/utils/sandbox.ts
@@ -1,0 +1,26 @@
+async function createSandboxProfile() : Promise<string> {
+    // create a sandbox profile that disallows
+    const profile = `
+;;; This sandbox-exec configuration disables writes to files under TEA_PREFIX
+;;;
+;;; Can be tested/verified by launching a new sandboxed shell:
+;;; $ sandbox-exec -f /path/to/sandbox-profile -D TEA_PREFIX="$HOME/.tea" fish
+
+(version 1)
+(define tea-prefix (param "TEA_PREFIX"))
+(allow default)
+(deny file-write* (subpath tea-prefix))
+`
+
+    const fp = await Deno.makeTempFile()
+    await Deno.writeTextFile(fp, profile)
+    return fp
+}
+
+export async function sandboxExecCmd(cmd: string[], teaPrefix: string) {
+    return ["sandbox-exec", 
+    "-f", await createSandboxProfile(),
+    "-D", `TEA_PREFIX=${teaPrefix}`,
+    "--", ...cmd]
+  }
+  


### PR DESCRIPTION
Runs the repl or commands inside a sandboxed environment.

The sandbox allows everything by default, and then disables writes to all files under TEA_PREFIX.

Fixes #77

--- 

edit: ok, there's quite a few tests at the moment that _expect_ TEA_PREFIX to be writeable 😅 