### PR TITLE
`tea --help` lists available targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ For an example see our “[dependencies](#dependencies)” section
 You can check what environment this generates with `tea`:
 
 ```sh
+# tea
 tea --env --dump
 ```
 

--- a/import-map.json
+++ b/import-map.json
@@ -15,6 +15,7 @@
     "s3": "https://deno.land/x/s3@0.5.0/mod.ts",
     "outdent": "https://deno.land/x/outdent@v0.8.0/mod.ts",
     "rimbu/": "https://deno.land/x/rimbu@0.12.3/",
-    "retried": "https://deno.land/x/retried@1.0.1/mod.ts"
+    "retried": "https://deno.land/x/retried@1.0.1/mod.ts",
+    "marked": "https://esm.sh/marked@4.2.4"
   }
 }

--- a/src/app.exec.ts
+++ b/src/app.exec.ts
@@ -75,7 +75,7 @@ async function refine(ass: RV2): Promise<RV1> {
     const filename = blueprint.file
     const sh = await useExecutableMarkdown({ filename }).findScript(ass.args[0]).swallow(/^not-found/)
     if (!sh) break // no exe/md target called this so just passthru
-    ass = { type: 'md', path: filename, sh, blueprint, name: ass.args[0], args: ass.args.slice(1) }
+    ass = { type: 'md', path: filename, sh: sh.code, blueprint, name: ass.args[0], args: ass.args.slice(1) }
   }}
 
   return ass
@@ -96,7 +96,7 @@ async function exec(ass: RV1, pkgs: PackageSpecification[], opts: {env: boolean}
     // ^^ jeez we’ve overcomplicated this shit
 
     const name = ass.name ?? 'getting-started'
-    const sh = ass.sh ?? await useExecutableMarkdown({ filename: ass.path }).findScript(name)
+    const sh = ass.sh ?? (await useExecutableMarkdown({ filename: ass.path }).findScript(name)).code
     const { pkgs } = await useRequirementsFile(ass.path) ?? panic()
     const { env } = await install(pkgs)
     const basename = ass.path.string.replaceAll("/", "_") //FIXME this is not sufficient escaping

--- a/tests/unit/exe∕md.test.ts
+++ b/tests/unit/exe∕md.test.ts
@@ -15,7 +15,7 @@ Deno.test("find-script-simple", async () => {
   const output = await useExecutableMarkdown({ text })
     .findScript("build")
 
-  assert(output === script)
+  assert(output.code === script)
 })
 
 Deno.test("find-script-complex", async () => {
@@ -50,7 +50,7 @@ Deno.test("find-script-complex", async () => {
   const output = await useExecutableMarkdown({ text })
     .findScript("deploy")
 
-  assert(output === script)
+  assert(output.code === script)
 })
 
 ////////////////////////////////////////////////////////////////////////// impl
@@ -76,7 +76,7 @@ Deno.test("tea build", async () => {
 
 ////////////////////////////////////////////////////////////////////////// util
 function fixture() {
-  const script = 'echo foo bar'
+  const script = '# tea\necho foo bar'
   const markdown = undent`
     \`\`\`sh
     ${script}


### PR DESCRIPTION
Closes #145.

Following is the help generated from [teaxyz/cli/README.md](https://raw.githubusercontent.com/teaxyz/cli/main/README.md)

```sh
usage:
  tea [-xdX] [flags] [+package~x.y] [file|URL|target|cmd|interpreter] -- [arg…]

modes:                                            magical?
  --exec,-x         execute
  --dump,-d         dump
  -X                magic execute
  𝑜𝑚𝑖𝑡𝑡𝑒𝑑           infer operation                  ✨

flags:
  --env,-E          inject virtual environment       ✨
  --sync,-S         sync pantries, etc. first        ✨
  --magic=no,-m     disable magic
  --verbose,-v      eg. tea -vv
  --silent,-s       no chat, no errors
  --cd,-C           change directory first

more:
  tea -vh
  open github.com/teaxyz/cli

targets:
  usage-as-an-environment-manager
    You can check what environment this generates with `tea`:
```