### PR TITLE
use version file

### DIFF
--- a/src/hooks/useVirtualEnv.ts
+++ b/src/hooks/useVirtualEnv.ts
@@ -65,7 +65,12 @@ export default async function useVirtualEnv(opts?: { cwd: Path }): Promise<Virtu
 
   if (files.length < 1) throw new TeaError("not-found: virtual-env", ctx)
 
-  const { file, version } = files.find(x => x.file.basename() == "README.md") ?? files[0]
+  const { file, version: req_version } = files.find(x => x.file.basename() == "README.md") ?? files[0]
+
+  const version_file = srcroot.join("VERSION").isFile()
+
+  const version = version_file ? semver.parse(await version_file.read()) ?? req_version : req_version
+
   const pkgs = files.flatMap(x => x.pkgs)
 
   //TODO magic deps should not conflict with requirements files deps


### PR DESCRIPTION
I think this does it. I'm at a loss for a test for it for the moment. `tea` doesn't seem to throw a version key for me.
```sh
$ tea -X deno run -A --import-map=import-map.json src/app.ts -Ed
set -gx SRCROOT '/Users/jacob/Work/Tea/pantry.core';
set -gx PATH '/Users/jacob/.tea/deno.land/v1.28.2/bin:/Users/jacob/.tea/deno.land/v1.28.2/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin';
set -gx MANPATH '/opt/homebrew/share/man:/usr/share/man:/usr/local/share/man:/Library/TeX/Distributions/.DefaultTeX/Contents/Man:/opt/homebrew/share/man:';
set -gx LDFLAGS '-Wl,-rpath,/Users/jacob/.tea';
set -gx TEA_PREFIX '/Users/jacob/.tea';
if functions --query fish_command_not_found; functions --erase fish_command_not_found; end
set -gx TEA_REWIND '{"PATH":["/Users/jacob/.tea/deno.land/v1.28.2/bin","/usr/local/bin","/usr/bin","/bin","/usr/sbin","/sbin"],"MANPATH":["/opt/homebrew/share/man","/usr/share/man","/usr/local/share/man","/Library/TeX/Distributions/.DefaultTeX/Contents/Man","/opt/homebrew/share/man",""],"LDFLAGS":["-Wl,-rpath,/Users/jacob/.tea"],"TEA_PREFIX":["/Users/jacob/.tea"]}';
$ echo 1.1.1 >VERSION
$ tea -X deno run -A --import-map=import-map.json src/app.ts -Ed
set -gx SRCROOT '/Users/jacob/Work/Tea/pantry.core';
set -gx PATH '/Users/jacob/.tea/deno.land/v1.28.2/bin:/Users/jacob/.tea/deno.land/v1.28.2/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin';
set -gx MANPATH '/opt/homebrew/share/man:/usr/share/man:/usr/local/share/man:/Library/TeX/Distributions/.DefaultTeX/Contents/Man:/opt/homebrew/share/man:';
set -gx LDFLAGS '-Wl,-rpath,/Users/jacob/.tea';
set -gx TEA_PREFIX '/Users/jacob/.tea';
if functions --query fish_command_not_found; functions --erase fish_command_not_found; end
set -gx TEA_REWIND '{"PATH":["/Users/jacob/.tea/deno.land/v1.28.2/bin","/usr/local/bin","/usr/bin","/bin","/usr/sbin","/sbin"],"MANPATH":["/opt/homebrew/share/man","/usr/share/man","/usr/local/share/man","/Library/TeX/Distributions/.DefaultTeX/Contents/Man","/opt/homebrew/share/man",""],"LDFLAGS":["-Wl,-rpath,/Users/jacob/.tea"],"TEA_PREFIX":["/Users/jacob/.tea"]}';
```

If this is right, it resolves #24