### PR TITLE
use mikepenz/release-changelog-builder-action for release changelogs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -145,10 +145,16 @@ jobs:
           git tag ${{ env.TAG }}
           git push origin ${{ env.TAG }}
 
+      - uses: mikepenz/release-changelog-builder-action@v3
+        id: build_changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.TAG }}
           files: artifacts/*
+          body_path: ${{ steps.build_changelog.outputs.changelog }}
           fail_on_unmatched_files: true
 
   upload-binaries:


### PR DESCRIPTION
obviously don't want to release just to test it; but we can roll it back if it's no good.