### PR TITLE
Possible fix to shell escaping env vars

### DIFF
--- a/import-map.json
+++ b/import-map.json
@@ -11,6 +11,7 @@
     "utils": "./src/utils/index.ts",
     "utils/": "./src/utils/",
     "is_what": "https://deno.land/x/is_what@v4.1.7/src/index.ts",
+    "shell_escape": "https://deno.land/x/shell_escape@1.0.0/index.ts",
     "cliffy/": "https://deno.land/x/cliffy@v0.25.2/",
     "s3": "https://deno.land/x/s3@0.5.0/mod.ts",
     "outdent": "https://deno.land/x/outdent@v0.8.0/mod.ts",


### PR DESCRIPTION
So. I'm not positive we should do this. This is solves the escaping of env vars in the proper `bash` way (as blessed by `shellcheck`), which is to use an array sets of things. This is good.

This is going to require changing numerous formulae in both pantries which rely on the old version of settings a single sell variable. This seems really, really bad.

You can test it by building a sample `package.yml` (I called it `foo`) that looks like this:

```yaml
distributable: ~

versions:
  - 0.0.1

build:
  script: |
    echo $ARGS
    for x in "${ARGS[@]}"; do
      echo "$x"
    done
  env:
    ARGS:
      - foo
      - bar
      - "baz bat"
      - --thing="foo bar"
      - "--thing=baz bat"

test: true
```

Since people shy away from bash arrays, I think it might be smarter just to treat them directly in the script rather than make this change wholesale. But I submit it for evaluation and discussion.