### PR TITLE
chore: bump deno std to latest

### DIFF
--- a/import-map.json
+++ b/import-map.json
@@ -14,6 +14,7 @@
     "cliffy/": "https://deno.land/x/cliffy@v0.25.2/",
     "s3": "https://deno.land/x/s3@0.5.0/mod.ts",
     "outdent": "https://deno.land/x/outdent@v0.8.0/mod.ts",
+    "sha256": "https://deno.land/std@0.160.0/hash/sha256.ts",
     "rimbu/": "https://deno.land/x/rimbu@0.12.3/"
   }
 }

--- a/import-map.json
+++ b/import-map.json
@@ -6,7 +6,7 @@
     "hooks/": "./src/hooks/",
     "prefab": "./src/prefab/index.ts",
     "prefab/": "./src/prefab/",
-    "deno/": "https://deno.land/std@0.172.0/",
+    "deno/": "https://deno.land/std@0.173.0/",
     "semver": "./src/utils/semver.ts",
     "utils": "./src/utils/index.ts",
     "utils/": "./src/utils/",

--- a/import-map.json
+++ b/import-map.json
@@ -6,7 +6,7 @@
     "hooks/": "./src/hooks/",
     "prefab": "./src/prefab/index.ts",
     "prefab/": "./src/prefab/",
-    "deno/": "https://deno.land/std@0.156.0/",
+    "deno/": "https://deno.land/std@0.172.0/",
     "semver": "./src/utils/semver.ts",
     "utils": "./src/utils/index.ts",
     "utils/": "./src/utils/",
@@ -14,7 +14,6 @@
     "cliffy/": "https://deno.land/x/cliffy@v0.25.2/",
     "s3": "https://deno.land/x/s3@0.5.0/mod.ts",
     "outdent": "https://deno.land/x/outdent@v0.8.0/mod.ts",
-    "rimbu/": "https://deno.land/x/rimbu@0.12.3/",
-    "retried": "https://deno.land/x/retried@1.0.1/mod.ts"
+    "rimbu/": "https://deno.land/x/rimbu@0.12.3/"
   }
 }

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -3,6 +3,7 @@ import { copy } from "deno/streams/copy.ts"
 import { Logger, teal, gray } from "./useLogger.ts"
 import { chuzzle, error, TeaError } from "utils"
 import { crypto, toHashString } from "deno/crypto/mod.ts";
+import { Sha256 } from "https://deno.land/std@0.160.0/hash/sha256.ts"
 import { usePrefix } from "hooks"
 import { isString } from "is_what"
 import Path from "path"
@@ -154,7 +155,7 @@ async function download_with_sha({ logger, ...opts}: DownloadOptions): Promise<{
     }})
   }
 
-  return { path, sha: toHashString(digest) }
+  return { path, sha: digest.hex() }
 }
 
 function hash_key(url: URL): Path {

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -117,12 +117,13 @@ async function download_with_sha({ logger, ...opts}: DownloadOptions): Promise<{
     logger = new Logger()
   }
 
-  const digest = new Sha256()
+  let buffer = new Uint8Array(0)
   let run = false
 
   // don’t fill CI logs with dozens of download percentage lines
   const ci = Deno.env.get("CI")
 
+  // TODO find a better way to find the hash of a file using web crypto
   const path = await internal({...opts, logger}, (src, dst, sz) => {
     let n = 0
 
@@ -130,8 +131,10 @@ async function download_with_sha({ logger, ...opts}: DownloadOptions): Promise<{
     const tee = src.tee()
     const p1 = copy(readerFromStreamReader(tee[0].getReader()), dst)
     const p2 = copy(readerFromStreamReader(tee[1].getReader()), { write: buf => {
-      //TODO in separate thread would be likely be faster
-      digest.update(buf)
+      const appendedBuffer = new Uint8Array(buffer.length + buf.length)
+      appendedBuffer.set(buffer, 0)
+      appendedBuffer.set(buf, buffer.length)
+      buffer = appendedBuffer
       if (sz && !ci) {
         n += buf.length
         const pc = Math.round(n / sz * 100);
@@ -148,13 +151,15 @@ async function download_with_sha({ logger, ...opts}: DownloadOptions): Promise<{
     logger.replace(teal('verifying'))
     const f = await Deno.open(path.string, { read: true })
     await copy(f, { write: buf => {
-      //TODO in separate thread would likely be faster
-      digest.update(buf)
+      const appendedBuffer = new Uint8Array(buffer.length + buf.length)
+      appendedBuffer.set(buffer, 0)
+      appendedBuffer.set(buf, buffer.length)
+      buffer = appendedBuffer
       return Promise.resolve(buf.length)
     }})
   }
 
-  return { path, sha: toHashString(digest) }
+  return { path, sha: toHashString(await crypto.subtle.digest("SHA-256", buffer)) }
 }
 
 function hash_key(url: URL): Path {

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -3,7 +3,7 @@ import { copy } from "deno/streams/copy.ts"
 import { Logger, teal, gray } from "./useLogger.ts"
 import { chuzzle, error, TeaError } from "utils"
 import { crypto, toHashString } from "deno/crypto/mod.ts";
-import { Sha256 } from "https://deno.land/std@0.160.0/hash/sha256.ts"
+import { Sha256 } from "sha256"
 import { usePrefix } from "hooks"
 import { isString } from "is_what"
 import Path from "path"

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -1,7 +1,8 @@
-import { readerFromStreamReader, copy } from "deno/streams/conversion.ts"
+import { readerFromStreamReader } from "deno/streams/reader_from_stream_reader.ts"
+import { copy } from "deno/streams/copy.ts"
 import { Logger, teal, gray } from "./useLogger.ts"
 import { chuzzle, error, TeaError } from "utils"
-import { Sha256 } from "deno/hash/sha256.ts"
+import { crypto, toHashString } from "deno/crypto/mod.ts";
 import { usePrefix } from "hooks"
 import { isString } from "is_what"
 import Path from "path"
@@ -153,13 +154,14 @@ async function download_with_sha({ logger, ...opts}: DownloadOptions): Promise<{
     }})
   }
 
-  return { path, sha: digest.hex() }
+  return { path, sha: toHashString(digest) }
 }
 
 function hash_key(url: URL): Path {
   function hash(url: URL) {
     const formatted = `${url.pathname}${url.search ? "?" + url.search : ""}`
-    return new Sha256().update(formatted).toString()
+    const contents = new TextEncoder().encode(formatted)
+    return toHashString(crypto.subtle.digestSync("SHA-256", contents))
   }
 
   const prefix = usePrefix().www

--- a/src/hooks/useExec.ts
+++ b/src/hooks/useExec.ts
@@ -93,7 +93,7 @@ async function install(pkgs: PackageSpecification[], update: boolean): Promise<I
   return installed
 }
 
-import { readLines } from "deno/io/buffer.ts"
+import { readLines } from "deno/io/read_lines.ts"
 
 async function read_shebang(path: Path) {
   const f = await Deno.open(path.string, { read: true })

--- a/src/vendor/Path.ts
+++ b/src/vendor/Path.ts
@@ -2,7 +2,7 @@ import { parse as parseYaml } from "deno/encoding/yaml.ts"
 import * as sys from "deno/path/mod.ts"
 import * as fs from "deno/fs/mod.ts"
 import { PlainObject } from "is_what"
-import {readLines} from "deno/io/buffer.ts"
+import { readLines } from "deno/io/read_lines.ts"
 import "utils"  //FIXME for console.verbose
 
 // based on https://github.com/mxcl/Path.swift


### PR DESCRIPTION
This is needed for https://github.com/teaxyz/pantry.core/pull/102 to land.

Marking this as a draft because there's one bit of code that doesn't have a clear transition path to the current standard library (since they removed `std/hash` in favor of the webcrypto api). Currently talking to the deno folks on how to best approach this.