### PR TITLE
Add `--provides` mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 # exlcluding this is temporary pre stability (ie. v1)
 /deno.lock
+
+.idea/

--- a/src/app.help.ts
+++ b/src/app.help.ts
@@ -51,6 +51,7 @@ export default async function help() {
         --help,-h
         --version,-v      prints tea’s version
         --prefix          prints the tea prefix †
+        --provides        exits successfully if package/s are provided
 
         † all packages are “stowed” in the tea prefix, eg. ~/.tea/rust-lang.org/v1.65.0
 

--- a/src/app.provides.ts
+++ b/src/app.provides.ts
@@ -1,0 +1,10 @@
+import {which} from "hooks/useExec.ts";
+
+export default async function provides(args: string[]) {
+  let status = 0;
+  for (const arg of args) {
+    const provides = await which(arg);
+    if (!provides) status = 1;
+  }
+  Deno.exit(status);
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import useFlags, { Args, useArgs } from "hooks/useFlags.ts"
 import syncf from "./app.sync.ts"
 import dump from "./app.dump.ts"
 import help from "./app.help.ts"
+import provides from "./app.provides.ts";
 import magic from "./app.magic.ts"
 import exec, { repl } from "./app.exec.ts"
 import { print, UsageError } from "utils"
@@ -57,6 +58,9 @@ try {
     break
   case "prefix":
     await print(usePrefix().string)
+    break
+  case "provides":
+    await provides(args.args)
     break
   case "magic":
     await print(magic(new Path(Deno.execPath())))

--- a/src/hooks/useExec.ts
+++ b/src/hooks/useExec.ts
@@ -164,7 +164,7 @@ type WhichResult = PackageRequirement & {
   shebang?: string
 }
 
-async function which(arg0: string | undefined) {
+export async function which(arg0: string | undefined) {
   if (!arg0?.chuzzle() || arg0.includes("/")) {
     // no shell we know allows searching for subdirectories off PATH
     return false

--- a/src/hooks/useFlags.ts
+++ b/src/hooks/useFlags.ts
@@ -44,7 +44,7 @@ export default function useFlags(): Flags & ConvenienceFlags {
 
 export type Args = {
   cd?: Path
-  mode: 'exec' | 'help' | 'version' | 'prefix' | 'magic'
+  mode: 'exec' | 'help' | 'version' | 'prefix' | 'magic' | 'provides'
   sync: boolean
   args: string[]
   pkgs: PackageSpecification[]
@@ -142,6 +142,10 @@ export function useArgs(args: string[], arg0: string): [Args, Flags & Convenienc
       case 'version':
         nonovalue()
         rv.mode = 'version'
+        break
+      case 'provides':
+        nonovalue()
+        rv.mode = 'provides'
         break
       case 'keep-going':
         keep_going = parseBool(value ?? "yes") ?? barf()


### PR DESCRIPTION
- `--provides` allows other programs like autocomplete to detect whether a program is available

Many people user terminals that automatically color the commandline depending on whether the program is available or not
This shaky gif demonstrates that (tea breaks vhs a bit)
![demo](https://user-images.githubusercontent.com/65569524/213879555-3c3a04a3-03b8-4c0d-be6b-e54f01f87ba7.gif)

`tea --provides [packages]` allows programs like `fish` to poll tea before highlighting commands which should lead to a better UX