### PR TITLE
`tea` is `env++`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -109,7 +109,7 @@ jobs:
         id: tea
         with:
           srcroot: tea
-      - run: sed -i.bak "s/^const version = .*$/const version = \"${{ steps.tea.outputs.version }}\"/" src/app.ts
+      - run: echo "export default function() { return '${{ steps.tea.outputs.version }}' }" >> src/hooks/useVersion.ts
         working-directory: tea
       - run: mv tea tea-${{ steps.tea.outputs.version }}
       - run: tar cJf tea-${{ steps.tea.outputs.version }}.tar.xz ./tea-${{ steps.tea.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,9 @@ jobs:
 
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: 1.27
+          deno-version: 1.29
           #FIXME get it out the README
-          #NOTE we are avoiding using tea here for revlock issues
+          #NOTE we are avoiding using tea here for revlock reasons
 
       - run: |
           deno compile \

--- a/README.md
+++ b/README.md
@@ -48,29 +48,6 @@ commands.
 
 Change your thinking from “I want to *install* foo” to “I want to *use* foo”.
 
-```sh
-$ which bun
-bun not found
-
-$ tea --dry-run bun --version
-imagined: bun.sh^0.4
-~/.tea/bun.sh/v0.4.0/bin/bun --version
-
-$ bun --version
-tea: installing bun.sh^0.4
-0.4.0
-
-$ which bun
-bun not found
-# `bun` is not in your `PATH`
-# ∵ tea doesn’t install packages
-# ∴ using tea doesn’t compromise your system’s integrity
-
-$ tea bun --version
-0.4.0
-# ^^ the same as `bun --version` but without magic
-```
-
 > Check out [# Magic](#magic) to learn how this works.
 
 Scripting’s been stuck in a dark age of Bash because it’s the only thing you
@@ -350,6 +327,29 @@ Our installer enables it by adding some hooks to your shell:
 > VSCode won’t magically find `deno`. Shell scripts won’t automatically
 > install tools they try to run. This is intentional. *Magic should not lead
 > to anarchy*. See our [FAQ](#faq) for more information.
+
+```sh
+$ which bun
+bun not found
+
+$ tea --dry-run bun --version
+imagined: bun.sh^0.4
+~/.tea/bun.sh/v0.4.0/bin/bun --version
+
+$ bun --version
+tea: installing bun.sh^0.4
+0.4.0
+
+$ which bun
+bun not found
+# `bun` is not in your `PATH`
+# ∵ tea doesn’t install packages
+# ∴ using tea doesn’t compromise your system’s integrity
+
+$ tea bun --version
+0.4.0
+# ^^ the same as `bun --version` but without magic
+```
 
 ## Using `tea` Without Magic
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the creator of [`brew`].
 &nbsp;
 
 
-# tea/cli 0.20.0
+# tea/cli 0.21.0
 
 ```sh
 $ node --eval 'console.log("Hello World!")'
@@ -65,6 +65,10 @@ bun not found
 # `bun` is not in your `PATH`
 # ∵ tea doesn’t install packages
 # ∴ using tea doesn’t compromise your system’s integrity
+
+$ tea bun --version
+0.4.0
+# ^^ the same as `bun --version` but without magic
 ```
 
 > Check out [# Magic](#magic) to learn how this works.
@@ -120,7 +124,7 @@ In fact you can construct *virtual environments* of specific tools and
 versions encapsulated and separate from the rest of your system.
 
 ```sh
-$ tea +rust-lang.org^1.63 +python.org~3.11
+$ tea +rust-lang.org^1.63 +python.org~3.11 sh
 tea: this is a temporary shell containing rust-lang.org, python.org and 13 other packages
 tea: type `exit` when done
 
@@ -225,9 +229,14 @@ As a bonus the installer also updates tea.
 
 ## “Now see here fella’, I \*hate\* installers…”
 
-We feel you—*there’s a reason we wrote a package manager*.
+It’s sad indeed that package managers can’t install themselves. Oh well.
+How about installing with `brew` instead?
 
-> <details><summary><i>Installing without the installer</i></summary><br>
+```sh
+$ brew install teaxyz/pkgs/tea-cli
+```
+
+> <details><summary><i>Other ways to install tea</i></summary><br>
 >
 > Take your pick:
 >

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -7,9 +7,9 @@
   "tasks": {
     "test": "deno test --allow-net --allow-read --allow-env --allow-run --allow-write --unstable",
     "typecheck": "deno check --unstable ./src/app.ts",
-    "run": "deno run --unstable --allow-all ./src/app.ts",
+    "run": "deno run --unstable --allow-all src/app.ts",
     "compile": "deno compile --allow-read --allow-write --allow-net --allow-run --allow-env --unstable --output $INIT_CWD/tea src/app.ts",
-    "install": "deno compile --allow-all --unstable --output $TEA_PREFIX/tea.xyz/v$VERSION/bin/tea src/app.ts && scripts/repair.ts tea.xyz"
+    "install": "deno compile --unstable -Ao $TEA_PREFIX/tea.xyz/v$VERSION/bin/tea src/app.ts && scripts/repair.ts tea.xyz"
   },
   // ignore all files since the current style deviates from deno's default style.
   "fmt": {
@@ -17,6 +17,11 @@
       "exclude": [
         "./"
       ]
+    }
+  },
+  "tea": {
+    "dependencies": {
+      "deno.land": "^1.29.2"
     }
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -7,8 +7,11 @@
   "tasks": {
     "test": "deno test --allow-net --allow-read --allow-env --allow-run --allow-write --unstable",
     "typecheck": "deno check --unstable ./src/app.ts",
+    // runs this source checkout for testing
     "run": "deno run --unstable --allow-all src/app.ts",
+    // compiles to ./tea
     "compile": "deno compile --allow-read --allow-write --allow-net --allow-run --allow-env --unstable --output $INIT_CWD/tea src/app.ts",
+    // installs this source checkout as a tea stowed package
     "install": "deno compile --unstable -Ao $TEA_PREFIX/tea.xyz/v$VERSION/bin/tea src/app.ts && scripts/repair.ts tea.xyz"
   },
   // ignore all files since the current style deviates from deno's default style.

--- a/src/app.help.ts
+++ b/src/app.help.ts
@@ -18,12 +18,12 @@ export default async function help() {
 
   10  flags:
         --sync,-S       sync and update environment packages
-        --env,-E        inject local environment
-        --dry-run,-n    don’t execute, just print
+  10    --env,-E        inject local environment
+        --dry-run,-n    don’t do anything, just print
 
   15  more:
         $ tea --verbose --help
-        $ open github.com/teaxyz/cli
+  15    $ open https://github.com/teaxyz/cli
       `)
   } else {
     //        10|       20|       30|       40|       50|       60|       70| |     80|
@@ -38,9 +38,10 @@ export default async function help() {
       flags:
         --sync,-S                synchronize and update the environment packages
         --env,-E                 inject the local environment
+        --dry-run,-n             don’t do anything, just print
         --keep-going,-k          keep going as much as possible after errors
         --verbose,-v             print version and then increase verbosity †
-        --silent,-s              no chat, no error messages (aka --verbose=-1)
+        --silent,-s              no chat, no errors: only output the requested data
         --cd,-C,--chdir <dir>    change directory first
         --chaste,-x              abstain from networking, installing packages, etc.
         --dry-run,-n             don’t execute, just print
@@ -53,22 +54,23 @@ export default async function help() {
       alt. modes:
         --help,-h
         --version,-v      prints tea’s version
-        --prefix          prints the tea prefix †
+        --prefix          prints the tea prefix ‡
         --provides        exits successfully if package/s are provided
 
+        ‡ all packages are “stowed” in the tea prefix, eg. ~/.tea/rust-lang.org/v1.65.0
         ‡ all packages are “stowed” in the tea prefix, eg. ~/.tea/rust-lang.org/v1.65.0
 
       environment variables:
         TEA_PREFIX    stow packages here
         TEA_MAGIC     if shell magic is active, \`TEA_MAGIC=0\` disables it
-        NO_COLOR      suppresses outputting color codes
+        CLICOLOR      see https://bixense.com/clicolors
         VERBOSE       {-1: silent, 0: default, 1: verbose, 2: debug}
         DEBUG         alias for \`VERBOSE=2\`
 
         • explicit flags override any environment variables
 
       ideology:
-        │ A successful tool is one that was used to do something undreamed of
+        │ a successful tool is one that was used to do something undreamed of
         │ by its author
           —𝑠ℎ𝑎𝑑𝑜𝑤𝑦 𝑠𝑢𝑝𝑒𝑟 𝑐𝑜𝑑𝑒𝑟
     `)

--- a/src/app.help.ts
+++ b/src/app.help.ts
@@ -13,15 +13,17 @@ export default async function help() {
       examples:
   05    $ tea node^19 --eval 'console.log("tea.xyz")'
         $ tea +nodejs.org man node
+        $ tea +bun.sh sh
+        # ^^ try out bun in an containerized shell
 
-      flags:
+  10  flags:
         --sync,-S       sync and update environment packages
-  10    --env,-E        inject local environment
+        --env,-E        inject local environment
         --dry-run,-n    don’t execute, just print
 
-      more:
+  15  more:
         $ tea --verbose --help
-  15    $ open github.com/teaxyz/cli
+        $ open github.com/teaxyz/cli
       `)
   } else {
     //        10|       20|       30|       40|       50|       60|       70| |     80|
@@ -29,23 +31,24 @@ export default async function help() {
       usage:
         tea [-SEnkhvs] [+package~x.y…] [cmd|file|URL] [--] [arg…]
 
-        • constructs the requested environment, installing packages as necessary
+        • assembles the requested environment, installing packages as necessary
         • magically determines additional packages based on the args
         • executes args in that environment
 
       flags:
         --sync,-S                synchronize and update the environment packages
         --env,-E                 inject the local environment
-        --dry-run,-n             don’t execute, just print
         --keep-going,-k          keep going as much as possible after errors
-        --verbose,-v             print version and then increase verbosity ‡
+        --verbose,-v             print version and then increase verbosity †
         --silent,-s              no chat, no error messages (aka --verbose=-1)
         --cd,-C,--chdir <dir>    change directory first
+        --chaste,-x              abstain from networking, installing packages, etc.
+        --dry-run,-n             don’t execute, just print
 
         • repetitions override previous values
         • long form boolean flags can be assigned, eg. --env=no
 
-        ‡ the short form accumulates, so \`-vv\` is more verbose
+        † the short form accumulates, so \`-vv\` is more verbose
 
       alt. modes:
         --help,-h
@@ -53,7 +56,7 @@ export default async function help() {
         --prefix          prints the tea prefix †
         --provides        exits successfully if package/s are provided
 
-        † all packages are “stowed” in the tea prefix, eg. ~/.tea/rust-lang.org/v1.65.0
+        ‡ all packages are “stowed” in the tea prefix, eg. ~/.tea/rust-lang.org/v1.65.0
 
       environment variables:
         TEA_PREFIX    stow packages here

--- a/src/app.magic.ts
+++ b/src/app.magic.ts
@@ -11,7 +11,7 @@ export default function(self: Path) {
     return undent`
       add-zsh-hook -Uz chpwd() {
         if [ "\${TEA_MAGIC:-}" != 0 -a -x "${d}"/tea ]; then
-          source <("${d}"/tea --env --keep-going --silent --dry-run=w/trace)
+          source <("${d}"/tea +tea.xyz/magic -Esk --chaste env)
         fi
       }
 
@@ -46,7 +46,7 @@ export default function(self: Path) {
       cd() {
         builtin cd "$@" || return
         if [ "$OLDPWD" != "$PWD" ]; then
-          source <("${d}"/tea --env --keep-going --silent --dry-run=w/trace)
+          source <("${d}"/tea +tea.xyz/magic -Esk --chaste env)
         fi
       }
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -16,6 +16,7 @@ import useVirtualEnv from "./useVirtualEnv.ts"
 import usePackageYAML, { usePackageYAMLFrontMatter } from "./usePackageYAML.ts"
 import useSync from "./useSync.ts"
 import useRequirementsFile from "./useRequirementsFile.ts"
+import useVersion from "./useVersion.ts"
 
 // but we can sort these alphabetically
 export {
@@ -31,9 +32,10 @@ export {
   usePackageYAMLFrontMatter,
   usePantry,
   usePrefix,
+  useRequirementsFile,
   useShellEnv,
   useSourceUnarchiver,
   useSync,
+  useVersion,
   useVirtualEnv,
-  useRequirementsFile
 }

--- a/src/hooks/useShellEnv.ts
+++ b/src/hooks/useShellEnv.ts
@@ -1,8 +1,7 @@
 import { Installation } from "types"
 import { OrderedHashSet } from "rimbu/ordered/set/index.ts"
-import { flatmap, host, pkg as pkgutils } from "utils"
+import { host } from "utils"
 import { usePrefix, usePantry } from "hooks"
-import { isArray } from "is_what"
 
 export const EnvKeys = [
   'PATH',
@@ -77,6 +76,7 @@ export default async function useShellEnv({installations}: Options): Promise<Rec
     // otherwise it bases it off the location
     // of python, which won't work for us
     if (installation.pkg.project === 'pip.pypa.io') {
+      //TODO add to pip’s runtime env keys
       vars.PYTHONPATH = compact_add(vars.PYTHONPATH, installation.path.string)
     }
 
@@ -107,22 +107,10 @@ export default async function useShellEnv({installations}: Options): Promise<Rec
     }
   }
 
-  const rewind = flatmap(Deno.env.get("TEA_REWIND"), x => JSON.parse(x)?.["PATH"])
-
   for (const key of EnvKeys) {
     //FIXME where is this `undefined` __happening__?
     if (vars[key] === undefined || vars[key]!.isEmpty) continue
     rv[key] = vars[key]!.toArray()
-
-    if (key == 'PATH') {
-      if (isArray(rewind)) {
-        rv[key] ??= []
-        rv[key].push(...rewind)
-      } else {
-        // first time we've stepped into a devenv
-        rv[key].push(...(Deno.env.get("PATH")?.split(":") ?? []))
-      }
-    }
   }
 
   if (isMac) {
@@ -131,12 +119,8 @@ export default async function useShellEnv({installations}: Options): Promise<Rec
     rv["LDFLAGS"] = [`-Wl,-rpath,${usePrefix()}`]
   }
 
-  rv["TEA_PREFIX"] = [usePrefix().string]
-
   // don’t break `man` lol
   rv["MANPATH"]?.push("/usr/share/man")
-
-  rv["TEA_PKGS"] = installations.map(x => pkgutils.str(x.pkg))
 
   return rv
 }

--- a/src/hooks/useShellEnv.ts
+++ b/src/hooks/useShellEnv.ts
@@ -157,7 +157,7 @@ export function expand(env: Record<string, string[]>) {
   let rv = ''
   for (const [key, value] of Object.entries(env)) {
     if (value.length == 0) continue
-    rv += `export ${key}='${value.join(":")}'\n`
+    rv += `export ${key}="${value.join(":")}"\n`
   }
   return rv
 }

--- a/src/hooks/useVersion.ts
+++ b/src/hooks/useVersion.ts
@@ -1,0 +1,14 @@
+import useRequirementsFile from "./useRequirementsFile.ts"
+
+const version = `${(
+  await useRequirementsFile(
+    new URL(import.meta.url).path()
+      .parent().parent().parent()
+      .join("README.md")
+  ).swallow(/not-found/))?.version}+dev`
+
+export default function() {
+  return version
+}
+
+// we statically replace this file at deployment

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -120,7 +120,8 @@ Array.prototype.chuzzle = function<T>() {
   }
 }
 
-console.verbose = console.log
+console.verbose = console.error
+console.debug = console.error
 
 console.silence = async function<T>(body: () => Promise<T>) {
   const originals = [console.log, console.info]

--- a/src/utils/pkg.ts
+++ b/src/utils/pkg.ts
@@ -2,7 +2,7 @@ import { Package, PackageRequirement } from "types"
 import * as semver from "semver"
 
 /// allows inputs `nodejs.org@16` when `semver.parse` would reject
-export function parse(input: string): PackageRequirement | Package {
+export function parse(input: string): PackageRequirement {
   const match = input.match(/^(.+?)([\^=~<>@].+)?$/)
   if (!match) throw new Error(`invalid pkgspec: ${input}`)
   if (!match[2]) match[2] = "*"
@@ -17,13 +17,7 @@ export function parse(input: string): PackageRequirement | Package {
     if (match[2].startsWith("@")) match[2] = `^${match[2].slice(1)}`
 
     const constraint = new semver.Range(match[2])
-    const version = constraint.single()
-
-    if (version) {
-      return { project, version }
-    } else {
-      return { project, constraint }
-    }
+    return { project, constraint }
   }
 }
 


### PR DESCRIPTION
`env` but with packaging.

`tea [+pkg]` by default now outputs like `env`. Previously it would start a “REPL”. You can still start a REPL with `tea +pkg sh` which is thus more idiomatic: tea now has no special modes, it installs packages, constructs an environment for them and either outputs envdata or executes cmds.

Typing `tea` when inside a dev-env now outputs the env, again: this is more idiomatic.

These patches also fix a number of conditions where the env was not present although its presence was expected. With 0.21 generally speaking if you type a command inside a dev-env the dependencies that project needs will install if necessary and be available to that command.