### PR TITLE
test fire teaxyz/setup:ci.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -199,3 +199,16 @@ jobs:
           aws cloudfront create-invalidation
             --distribution-id ${{ secrets.AWS_CF_DISTRIBUTION_ID }}
             --paths
+
+  smoke-setup:
+    needs: [upload-binaries]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: aurelien-baudet/workflow-dispatch@v2
+      with:
+        workflow: ci.yml
+        inputs: "{\"cli-release\": \"true\"}"
+        repo: teaxyz/setup
+        ref: main
+        token: ${{secrets.TEMP_JACOBS_GITHUB_PAT}}
+        wait-for-completion: false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -206,8 +206,7 @@ jobs:
     steps:
     - uses: aurelien-baudet/workflow-dispatch@v2
       with:
-        workflow: ci.yml
-        inputs: "{\"cli-release\": \"true\"}"
+        workflow: smoke-test.yml
         repo: teaxyz/setup
         ref: main
         token: ${{secrets.TEMP_JACOBS_GITHUB_PAT}}


### PR DESCRIPTION
resolves https://github.com/teaxyz/setup/issues/122

If we don't want to fail if CI does (but then what?), set `wait-for-completion: false` on the `smoke-setup:` job's single step.