### PR TITLE
implement tea-magic in rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ shell’s configuration file.
 Our magic is not automatically added to scripts, but you can manually add it:
 
 ```sh
-source <(tea --magic=bash)
+source <(tea-magic bash)
                    # ^^ you have to specify which shell tho
 ```
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -11,8 +11,10 @@
     "run": "deno run --unstable --allow-all src/app.ts",
     // compiles to ./tea
     "compile": "deno compile --allow-read --allow-write --allow-net --allow-run --allow-env --unstable --output $INIT_CWD/tea src/app.ts",
+    // compiles to ./tea-magic
+    "compile-magic": "rustc -C opt_level=3 -o $INIT_CWD/tea-magic src/tea-magic/main.rs",
     // installs this source checkout as a tea stowed package
-    "install": "deno compile --unstable -Ao $TEA_PREFIX/tea.xyz/v$VERSION/bin/tea src/app.ts && scripts/repair.ts tea.xyz"
+    "install": "deno compile --unstable -Ao $TEA_PREFIX/tea.xyz/v$VERSION/bin/tea src/app.ts && rustc -C opt_level=3 -o $TEA_PREFIX/tea.xyz/v$VERSION/bin/tea-magic src/tea-magic/main.rs && scripts/repair.ts tea.xyz"
   },
   // ignore all files since the current style deviates from deno's default style.
   "fmt": {

--- a/src/tea-magic/main.rs
+++ b/src/tea-magic/main.rs
@@ -1,0 +1,122 @@
+use std::{env, path::PathBuf};
+
+fn main() {
+    let exe = env::current_exe().unwrap();
+    let shell = env::args().nth(1);
+
+    magic(exe, shell);
+}
+
+fn magic(exe: PathBuf, shell: Option<String>) {
+    let shell = if let Some(s) = shell {
+        s
+    } else {
+        env::var("SHELL").unwrap_or("unknown".to_string())
+    };
+
+    let base_path = exe.parent().unwrap().display().to_string();
+
+    let magic = match shell.as_str() {
+        "zsh" => {
+            format!(
+                "add-zsh-hook -Uz chpwd() {{
+  if [ \"${{TEA_MAGIC:-}}\" != 0 -a -x \"{base_path}\"/tea ]; then
+    source <(\"{base_path}\"/tea +tea.xyz/magic -Esk --chaste env)
+  fi
+}}
+
+# if the user put tea in eg. /usr/local/bin then don’t pollute their PATH
+# we check for `tea --prefix` due to `gitea` being `tea` when installed with `brew`
+if ! command -v tea 2>&1 >/dev/null || ! tea --prefix 2>&1 >/dev/null; then
+  export PATH=\"{base_path}:$PATH\"
+fi
+
+function command_not_found_handler {{
+  if [ \"${{TEA_MAGIC:-}}\" != 0 -a -x \"{base_path}\"/tea ]; then
+    \"{base_path}\"/tea -- $*
+  fi
+}}"
+            )
+        }
+        "elvish" => {
+            format!(
+                "set after-chdir = [ $@after-chdir {{ |dir|
+  eval (\"{base_path}\"/tea +tea.xyz/magic -Esk --chaste env | slurp)
+}}]
+
+# insert env for current dir too
+eval (\"{base_path}\"/tea +tea.xyz/magic -Esk --chaste env | slurp)
+
+# if the user put tea in eg. /usr/local/bin then don’t pollute their PATH
+if (not (has-external tea)) {{
+  set paths = [
+    {base_path}
+    $@paths
+  ]
+}}
+
+# command-not-found
+set edit:after-command = [ $@edit:after-command {{ |m|
+  var error = $m[error]
+  var src = $m[src]
+
+  if (not-eq $error $nil) {{
+    var reason
+
+    try {{
+      set reason = $error[reason]
+    }} catch {{
+      set reason = \"\"
+    }}
+
+    use str
+    if (str:has-prefix (repr $reason) \"<unknown exec:\") {{
+      \"{base_path}\"/tea (str:split &max=-1 ' ' $src[code])
+    }}
+  }}
+}}]"
+            )
+        }
+        "fish" => {
+            format!(
+                "function add_tea_environment --on-variable PWD
+  \"{base_path}\"/tea --env --keep-going --silent --dry-run=w/trace | source
+end
+
+# if the user put tea in eg. /usr/local/bin then don’t pollute their PATH
+# we check for `tea --prefix` due to `gitea` being `tea` when installed with `brew`
+if ! command -v tea 2>&1 >/dev/null || ! tea --prefix 2>&1 >/dev/null
+  export PATH=\"{base_path}:$PATH\"
+end
+
+function fish_command_not_found
+  \"{base_path}\"/tea -- $argv
+end"
+            )
+        }
+        "bash" => {
+            format!(
+                "cd() {{
+  builtin cd \"$@\" || return
+  if [ \"$OLDPWD\" != \"$PWD\" ]; then
+    source <(\"{base_path}\"/tea +tea.xyz/magic -Esk --chaste env)
+  fi
+}}
+
+# if the user put tea in eg. /usr/local/bin then don’t pollute their PATH
+# we check for `tea --prefix` due to `gitea` being `tea` when installed with `brew`
+if ! command -v tea 2>&1 >/dev/null || ! tea --prefix 2>&1 >/dev/null; then
+  export PATH=\"{base_path}:$PATH\"
+fi
+
+function command_not_found_handle {{
+  \"{base_path}\"/tea -- $*
+}}"
+            )
+        }
+        _ => {
+            format!("unsupported shell")
+        }
+    };
+    println!("{}", magic);
+}


### PR DESCRIPTION
resolves https://github.com/teaxyz/cli/issues/341, maybe

```sh
$ hyperfine --warmup=3 "tea --magic" 
Benchmark 1: tea --magic
  Time (mean ± σ):      47.5 ms ±   1.3 ms    [User: 43.3 ms, System: 3.4 ms]
  Range (min … max):    46.2 ms …  53.8 ms    60 runs
 
$ hyperfine --warmup=3 "./tea-magic zsh"
Benchmark 1: ./tea-magic zsh
  Time (mean ± σ):       0.6 ms ±   0.5 ms    [User: 0.3 ms, System: 0.2 ms]
  Range (min … max):     0.2 ms …   9.4 ms    1084 runs
 
  Warning: Command took less than 5 ms to complete. Note that the results might be inaccurate because hyperfine can not calibrate the shell startup time much more precise than this limit. You can try to use the `-N`/`--shell=none` option to disable the shell completely.
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
```

slight performance gains. would need support in `teaxyz/setup` and `teaxyz/pantry.core`.