### PR TITLE
fixes a panic:bad-yaml when deno.jsonc doesn't have tea dependencies

### DIFF
--- a/src/hooks/useVirtualEnv.ts
+++ b/src/hooks/useVirtualEnv.ts
@@ -107,7 +107,9 @@ export default async function(cwd: Path = Path.cwd()): Promise<VirtualEnv> {
     if (_if("deno.json", "deno.jsonc")) {
       pkgs.push({project: "deno.land", constraint})
       const json = JSONC.parse(await f!.read())
-      insert(refineFrontMatter(json?.tea, srcroot))
+      if (isPlainObject(json?.tea)) {
+        insert(refineFrontMatter(json?.tea, srcroot))
+      }
     }
     if (_if(".node-version")) {
       const constraint = semver.Range.parse((await f!.read()).trim())


### PR DESCRIPTION
When a deno configuration file didnt't have a tea section listed, tea would panic when sourcing the local environment.

    Error: bad-yaml
        at usePackageYAML (file:///opt/tea.xyz/src-v0.24.3/src/hooks/usePackageYAML.ts:9:37)
        at refineFrontMatter (file:///opt/tea.xyz/src-v0.24.3/src/hooks/usePackageYAML.ts:30:16)
        at supp (file:///opt/tea.xyz/src-v0.24.3/src/hooks/useVirtualEnv.ts:109:20)
        at async default (file:///opt/tea.xyz/src-v0.24.3/src/hooks/useVirtualEnv.ts:24:13)
        at async file:///opt/tea.xyz/src-v0.24.3/src/app.ts:24:21

Fixes https://github.com/teaxyz/cli/issues/384, specifically: https://github.com/teaxyz/cli/issues/384#issuecomment-1434593366