### PR TITLE
move variants added to Deno.build.os on v1.31.0

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -305,6 +305,8 @@ export function host(): HostReturnValue {
       case "aarch64": return "aarch64"
       case "x86_64": return "x86-64"
       // ^^ ∵ https://en.wikipedia.org/wiki/X86-64 and semver.org prohibits underscores
+      default:
+        throw new Error(`unsupported-arch: ${Deno.build.arch}`)
     }
   })()
 
@@ -316,12 +318,9 @@ export function host(): HostReturnValue {
       case "linux":
       case "windows":
         return Deno.build.os
-      case "freebsd":
-      case "netbsd":
-      case "aix":
-      case "solaris":
-      case "illumos":
-        throw new Error(`unsupported-os: ${Deno.build.os}`)
+      default:
+        console.warn("assuming linux mode for:", Deno.build.os)
+        return 'linux'
     }
   })()
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -308,7 +308,22 @@ export function host(): HostReturnValue {
     }
   })()
 
-  const { os: platform, target } = Deno.build
+  const { target } = Deno.build
+
+  const platform = (() => {
+    switch (Deno.build.os) {
+      case "darwin":
+      case "linux":
+      case "windows":
+        return Deno.build.os
+      case "freebsd":
+      case "netbsd":
+      case "aix":
+      case "solaris":
+      case "illumos":
+        throw new Error(`unsupported-os: ${Deno.build.os}`)
+    }
+  })()
 
   return {
     platform,

--- a/src/vendor/Path.ts
+++ b/src/vendor/Path.ts
@@ -28,16 +28,10 @@ export default class Path {
   static home(): Path {
     return new Path((() => {
       switch (Deno.build.os) {
-        case "linux":
-        case "darwin":
-        case "freebsd":
-        case "netbsd":
-        case "aix":
-        case "solaris":
-        case "illumos":
-          return Deno.env.get("HOME")!
         case "windows":
           return Deno.env.get("USERPROFILE")!
+        default:
+          return Deno.env.get("HOME")!
       }
     })())
   }

--- a/src/vendor/Path.ts
+++ b/src/vendor/Path.ts
@@ -30,6 +30,11 @@ export default class Path {
       switch (Deno.build.os) {
         case "linux":
         case "darwin":
+        case "freebsd":
+        case "netbsd":
+        case "aix":
+        case "solaris":
+        case "illumos":
           return Deno.env.get("HOME")!
         case "windows":
           return Deno.env.get("USERPROFILE")!


### PR DESCRIPTION
https://github.com/denoland/deno/pull/17340

fixes #405

- [x] add additional variants to two cases that switch `Deno.build.os`
- [x] bump req to `deno.land^1.31.0`
- [x] fix expected return code in unit test