### PR TITLE
Issue#324 - add test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
       - run: deno task test --coverage=cov_profile
       - run: deno coverage cov_profile --lcov --output=cov_profile.lcov
       - name: coveralls
-          uses: coverallsapp/github-action@master
-          with:
-            github-token: ${{ secrets.GITHUB_TOKEN }}
-            path-to-lcov: cov_profile.lcov
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: cov_profile.lcov
 
   # run tests for non-ubuntu OS's
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # run tests + coverage for unbuntu
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/cache  # avoids sporadic 500s from deno’s CDN
+      - uses: denoland/setup-deno@v1   # using ourself to install deno could compromise the tests
+      - run: deno task test --coverage=cov_profile
+      - run: deno coverage cov_profile --lcov --output=cov_profile.lcov
+      - name: coveralls
+          uses: coverallsapp/github-action@master
+          with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            path-to-lcov: cov_profile.lcov
+
+  # run tests for non-ubuntu OS's
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -21,7 +37,6 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/cache  # avoids sporadic 500s from deno’s CDN

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           parallel: true
 
   finish-tests:
-    needs: test
+    needs: tests
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: cov_profile.lcov
           parallel: true
+          flag-name: ${{ matrix.os }}
 
   finish-tests:
     needs: tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # run tests + coverage for unbuntu
-  coverage:
-    runs-on: ubuntu-latest
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/cache  # avoids sporadic 500s from deno’s CDN
@@ -28,20 +33,18 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: cov_profile.lcov
+          parallel: true
 
-  # run tests for non-ubuntu OS's
-  tests:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-latest
+  finish-tests:
+    needs: test
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/cache  # avoids sporadic 500s from deno’s CDN
-      - uses: denoland/setup-deno@v1   # using ourself to install deno could compromise the tests
-      - run: deno task test
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        parallel-finished: true
 
   lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /deno.lock
 
 .idea/
+cov_profile**

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
   <a href="#">
     <img src="https://img.shields.io/github/v/release/teaxyz/cli?label=tea/cli&color=ff00ff" alt="Version" />
   </a>
+  <a href='https://coveralls.io/github/teaxyz/cli?branch=main'>
+    <img src='https://coveralls.io/repos/github/teaxyz/cli/badge.svg?branch=main' alt='Coverage Status' />
+  </a>
 </p>
 
 Package managers are the foundation of every stack yet they haven’t evolved


### PR DESCRIPTION
Adding test coverage with coveralls.io.  Coverage is only counted for the ubuntu tests.  

fixes #324