### PR TITLE
Add user-agent header

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -6,6 +6,7 @@ import useDownload from "./useDownload.ts"
 import useCache from "./useCache.ts"
 import useCellar from "./useCellar.ts"
 import useExec from "./useExec.ts"
+import useFetch from "./useFetch.ts"
 import useFlags from "./useFlags.ts"
 import useGitHubAPI from "./useGitHubAPI.ts"
 import useInventory from "./useInventory.ts"
@@ -24,6 +25,7 @@ export {
   useCellar,
   useDownload,
   useExec,
+  useFetch,
   useFlags,
   useGitHubAPI,
   useInventory,

--- a/src/hooks/useDownload.ts
+++ b/src/hooks/useDownload.ts
@@ -3,7 +3,7 @@ import { copy } from "deno/streams/copy.ts"
 import { Logger, teal, gray } from "./useLogger.ts"
 import { chuzzle, error, TeaError } from "utils"
 import { crypto, toHashString } from "deno/crypto/mod.ts";
-import { usePrefix } from "hooks"
+import { useFetch, usePrefix } from "hooks"
 import { isString } from "is_what"
 import Path from "path"
 
@@ -65,7 +65,7 @@ async function internal<T>({ src, dst, headers, logger }: DownloadOptions,
     }
   }
 
-  const rsp = await fetch(src, {headers})
+  const rsp = await useFetch(src, { headers })
 
   switch (rsp.status) {
   case 200: {

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -1,0 +1,8 @@
+import { useVersion } from "hooks";
+
+// useFetch wraps the native Deno fetch api and inserts a User-Agent header
+export default function useFetch(input: string | URL | Request, init?: RequestInit | undefined): Promise<Response> {
+    const requestInit = init ?? {} as RequestInit
+    requestInit.headers = { ...requestInit.headers, "User-Agent": `tea-cli/${useVersion()}` }
+    return fetch(input,  requestInit)
+}

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -3,6 +3,6 @@ import { useVersion } from "hooks";
 // useFetch wraps the native Deno fetch api and inserts a User-Agent header
 export default function useFetch(input: string | URL | Request, init?: RequestInit | undefined): Promise<Response> {
     const requestInit = init ?? {} as RequestInit
-    requestInit.headers = { ...requestInit.headers, "User-Agent": `tea-cli/${useVersion()}` }
+    requestInit.headers = { ...requestInit.headers, "User-Agent": `tea(cli)/${useVersion()}` }
     return fetch(input,  requestInit)
 }

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -3,6 +3,6 @@ import { useVersion } from "hooks";
 // useFetch wraps the native Deno fetch api and inserts a User-Agent header
 export default function useFetch(input: string | URL | Request, init?: RequestInit | undefined): Promise<Response> {
     const requestInit = init ?? {} as RequestInit
-    requestInit.headers = { ...requestInit.headers, "User-Agent": `tea(cli)/${useVersion()}` }
+    requestInit.headers = { ...requestInit.headers, "User-Agent": `tea.cli/${useVersion()}` }
     return fetch(input,  requestInit)
 }

--- a/src/hooks/useGitHubAPI.ts
+++ b/src/hooks/useGitHubAPI.ts
@@ -1,5 +1,6 @@
 import { GET2, undent, validate_arr, validate_str } from "utils"
 import { isArray } from "is_what"
+import { useFetch } from "hooks";
 
 //TODO pagination
 
@@ -66,7 +67,7 @@ async function *getVersions({ user, repo, type }: GetVersionsOptions): AsyncGene
             }
           }
         }`
-      const rsp = await fetch('https://api.github.com/graphql', {
+      const rsp = await useFetch('https://api.github.com/graphql', {
         method: 'POST',
         body: JSON.stringify({ query }),
         headers

--- a/src/hooks/useInventory.ts
+++ b/src/hooks/useInventory.ts
@@ -2,6 +2,7 @@ import { Package, PackageRequirement } from "types"
 import { host, error, TeaError } from "utils"
 import SemVer from "semver"
 import Path from "../vendor/Path.ts"
+import { useFetch } from "hooks";
 
 export interface Inventory {
   [project: string]: {
@@ -29,7 +30,7 @@ const get = async (rq: PackageRequirement | Package) => {
   const url = new URL('https://dist.tea.xyz')
   url.pathname = Path.root.join(rq.project, platform, arch, 'versions.txt').string
 
-  const rsp = await fetch(url)
+  const rsp = await useFetch(url)
 
   if (!rsp.ok) {
     const cause = new Error(`${rsp.status}: ${url}`)

--- a/src/prefab/install.ts
+++ b/src/prefab/install.ts
@@ -1,4 +1,4 @@
-import { usePrefix, useCache, useCellar, useFlags, useDownload, useOffLicense } from "hooks"
+import { usePrefix, useCache, useCellar, useFlags, useDownload, useOffLicense, useFetch } from "hooks"
 import { run, TarballUnarchiver, host, pkg as pkgutils } from "utils"
 import { Installation, StowageNativeBottle } from "types"
 import { Logger, red, teal, gray } from "hooks/useLogger.ts"
@@ -115,7 +115,7 @@ export default async function install(pkg: Package, logger?: Logger): Promise<In
 
 async function sumcheck(local_SHA: string, url: URL) {
   const remote_SHA = await (async () => {
-    const rsp = await fetch(url)
+    const rsp = await useFetch(url)
     if (!rsp.ok) throw rsp
     const txt = await rsp.text()
     return txt.split(' ')[0]


### PR DESCRIPTION
I created a useFetch hook that wraps the Deno `fetch` function and automatically adds a `User-Agent` header to the request.

The header looks like `User-Agent: tea.cli/0.24.9`