### PR TITLE
fix magic for bash

### DIFF
--- a/src/app.magic.ts
+++ b/src/app.magic.ts
@@ -99,7 +99,7 @@ export default function(self: Path, shell?: string) {
     return undent`
       cd() {
         builtin cd "$@" || return
-        source <("${d}"/tea +tea.xyz/magic -Esk --chaste env)
+        source /dev/stdin <<<"$("${d}"/tea +tea.xyz/magic -Esk --chaste env)"
       }
 
       if [[ "$PATH" != *"$HOME/.local/bin"* ]]; then


### PR DESCRIPTION
Magic currently fails on bash 3.2 (the default version of bash that ships with macOS).
This is due to a [bug in bash 3.2 related to sourcing from a process substitution.](https://lists.gnu.org/archive/html/bug-bash/2006-01/msg00018.html)

This is a known workaround that will work for bash 3.x and newer versions.

Note that although this fixes the sourcing issue, there are other issues with magic when running bash 3.2 (`command_not_found_handler` doesn't work)
 
Closes #450 