### PR TITLE
Integration tests should catch fish syntax errors

### DIFF
--- a/tests/integration/magic.test.ts
+++ b/tests/integration/magic.test.ts
@@ -100,3 +100,24 @@ it(suite, "tea --magic in a script. fish", async function() {
 
   await this.run({ args: [script.string] })
 })
+
+
+it(suite, "tea verify --magic is parsed correctly by fish", async function() {
+  const script = this.sandbox.join("magic-fish").write({ text: undent`
+    #!/usr/bin/fish
+
+    tea --magic=fish | source
+
+    `})
+
+  // fish doesn't have an equivalent of bash's "set -e" to exit the script if an error occurs
+  // for more information go here: https://github.com/fish-shell/fish-shell/issues/510
+  // we will assume if stderr contains anything that isn't prefixed with tea that then 
+  // an error occurred
+  const stderr = await this.run({ args: [script.string] }).stderr()
+
+  const errorLines = stderr.split("\n")
+    .compact(x => strip_ansi_escapes(x).trim())
+    .filter(x => !x.startsWith("tea:"))
+  assertEquals(errorLines, [])
+})


### PR DESCRIPTION
Fish doesn't have an equivalent of bash's `set -e` so even though it fails to source tea's magic, the script continues to run. 

There isn't a great way to detect an error when sourcing a fish script because the exit code of `source` is only for the last command run.  I added a check in the test for anything going to stderr that wasn't from tea to help catch syntax errors.

Unfortunately as I needed to check both stderr and stdout I also refactored the integration test suite so that the exit code, stdout, and stderr are always available.  This change is actually the bulk of the PR.