### PR TITLE
coverage script should use tea

### DIFF
--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -1,4 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env tea
+
+#---
+# dependencies:
+#   github.com/linux-test-project/lcov: 1.16.0
+#---
 
 set -e
 

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env tea
+#!/usr/bin/env -S tea
 
 #---
 # dependencies:


### PR DESCRIPTION
Now that `lcov` is packaged this script can be updated to use tea