### PR TITLE
dark magic v0

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -19,6 +19,7 @@ import useErrorHandler from "hooks/useErrorHandler.ts"
 import usePrint from "hooks/usePrint.ts"
 import useRun from "hooks/useRun.ts"
 import useConfig, { useEnv } from "hooks/useConfig.ts"
+import useDarkMagic from "hooks/useDarkMagic.ts"
 
 // but we can sort these alphabetically
 export {
@@ -43,4 +44,5 @@ export {
   useRun,
   useConfig,
   useEnv,
+  useDarkMagic,
 }

--- a/src/hooks/useDarkMagic.ts
+++ b/src/hooks/useDarkMagic.ts
@@ -1,0 +1,30 @@
+import { Range } from "semver"
+import { useFetch } from "hooks"
+
+export default function useDarkMagic() {
+  return { which }
+}
+
+const which = async (arg0: string | undefined) => {
+  // Query external providers; return commands to run if found
+  const found = await Promise.all([
+    npx(arg0),
+  ])
+
+  // Return the first non-empty result
+  return found.find(x => x)
+}
+
+const npx = async (arg0: string | undefined) => {
+  const res = await useFetch(`https://registry.npmjs.org/${arg0}`)
+
+  if (res.status == 200) {
+    return {
+      project: "npmjs.com",
+      constraint: new Range("*"),
+      shebang: ["npx", "-q"]
+    }
+  }
+
+  return undefined
+}

--- a/src/hooks/useExec.ts
+++ b/src/hooks/useExec.ts
@@ -287,6 +287,18 @@ export async function which(arg0: string | undefined) {
     return found
   }
 
+  // dark-magic will find a _lot_ of things, even when we might not want to.
+  // https://www.npmjs.com/package/sh is a great example, and probably not what
+  // we're looking for if we say `tea sh` (which is a common thing to do).
+  // So, we should only pass through if the tool we want isn't on the path.
+  const { env } = useConfig()
+  if (env.PATH) {
+    for (const dir of env.PATH.split(":")) {
+      const path = new Path(dir).join(arg0)
+      if (path.isExecutableFile()) return false
+    }
+  }
+
   // Here is where we check our dark magic providers for the name in question.
   return useDarkMagic().which(arg0)
 }

--- a/tests/functional/provides.test.ts
+++ b/tests/functional/provides.test.ts
@@ -22,11 +22,16 @@ Deno.test("provides", { sanitizeResources: false, sanitizeOps: false }, async te
 
   await test.step("does not provide", async () => {
     const { run } = await createTestHarness()
-    await assertRejects(() => run(["--provides", "foobar"]), ExitError, "exiting with code: 1")
+    await assertRejects(() => run(["--provides", "this-isn't-a-real-package-name"]), ExitError, "exiting with code: 1")
   })
 
   await test.step("does not provide version", async () => {
     const { run } = await createTestHarness()
     await assertRejects(() => run(["--provides", "node@newest"]), ExitError, "exiting with code: 1")
+  })
+
+  await test.step("dark magic provides -- npx create-react-app", async () => {
+    const { run } = await createTestHarness()
+    await assertRejects(() => run(["--provides", "create-react-app"]), ExitError, "exiting with code: 0")
   })
 })


### PR DESCRIPTION
picked the easiest one first
- if no other resolution fails, query `registry.npmjs.org`
- if that finds a package, return `["npx", "-q"]` as the shebang
- hookify it all to make extension simple
- use `Promise.all` to parallelize the search