### PR TITLE
`PathUtils.ts`: search and manage `$PATH`

### DIFF
--- a/import-map.json
+++ b/import-map.json
@@ -1,6 +1,7 @@
 {
   "imports": {
     "path": "./src/vendor/Path.ts",
+    "path-utils": "./src/vendor/PathUtils.ts",
     "types": "./src/types.ts",
     "hooks": "./src/hooks/index.ts",
     "hooks/": "./src/hooks/",

--- a/src/hooks/useExec.ts
+++ b/src/hooks/useExec.ts
@@ -7,6 +7,7 @@ import useLogger from "./useLogger.ts"
 import { pkg as pkgutils, TeaError } from "utils"
 import * as semver from "semver"
 import Path from "path"
+import PathUtils from "path-utils"
 import { isArray } from "is_what"
 
 interface Parameters {
@@ -292,12 +293,7 @@ export async function which(arg0: string | undefined) {
   // we're looking for if we say `tea sh` (which is a common thing to do).
   // So, we should only pass through if the tool we want isn't on the path.
   const { env } = useConfig()
-  if (env.PATH) {
-    for (const dir of env.PATH.split(":")) {
-      const path = new Path(dir).join(arg0)
-      if (path.isExecutableFile()) return false
-    }
-  }
+  if (PathUtils.findBinary(arg0, env.PATH)) return false
 
   // Here is where we check our dark magic providers for the name in question.
   return useDarkMagic().which(arg0)

--- a/src/vendor/PathUtils.ts
+++ b/src/vendor/PathUtils.ts
@@ -1,0 +1,40 @@
+import Path from "path"
+
+export default {
+  envPath,
+  addPath,
+  rmPath,
+  findBinary,
+}
+
+function envPath(pathVar: string | undefined = undefined): Path[] {
+  const pathVar_ = pathVar || Deno.env.get("PATH")!
+  return pathVar_.split(":").map(x => new Path(x))
+}
+
+function addPath(path: Path | string, pathVar: string | undefined = undefined): Path[] {
+  const pathVar_ = envPath(pathVar)
+  const path_ = new Path(path)
+  if (!pathVar_.includes(path_)) {
+    pathVar_.push(path_)
+    Deno.env.set("PATH", pathVar_.join(":"))
+  }
+  return pathVar_
+}
+
+function rmPath(path: Path | string, pathVar: string | undefined = undefined): Path[] {
+  const path_ = new Path(path)
+  const pathVar_ = envPath(pathVar).filter(x => x.string != path_.string)
+  Deno.env.set("PATH", pathVar_.join(":"))
+  return pathVar_
+}
+
+function findBinary(name: string, pathVar: string | Path[] | undefined = undefined): Path | undefined {
+  let pathVar_: Path[]
+  if (pathVar instanceof Array) {
+    pathVar_ = pathVar
+  } else {
+    pathVar_ = envPath(pathVar)
+  }
+  return pathVar_.find(x => x.join(name).isExecutableFile())?.join(name)
+}

--- a/src/vendor/README.md
+++ b/src/vendor/README.md
@@ -13,6 +13,7 @@ Goals:
 
 Based on [mxcl/Path.swift](https://github.com/mxcl/Path.swift)
 
+<!-- markdownlint-disable-next-line MD025 -->
 # PathUtils.ts
 
 Companion library to `Path.ts`. Contains common path-oriented

--- a/src/vendor/README.md
+++ b/src/vendor/README.md
@@ -12,3 +12,8 @@ Goals:
 6. Consistent
 
 Based on [mxcl/Path.swift](https://github.com/mxcl/Path.swift)
+
+# PathUtils.ts
+
+Companion library to `Path.ts`. Contains common path-oriented
+operations that don't specifically belong on a `Path` object.

--- a/tests/unit/path-utils.test.ts
+++ b/tests/unit/path-utils.test.ts
@@ -1,0 +1,48 @@
+import Path from "path"
+import PathUtils from "path-utils"
+import { assertArrayIncludes, assertEquals } from "deno/testing/asserts.ts"
+
+Deno.test("test PathUtils", async test => {
+  await test.step("modify $PATH", () => {
+    const envPath = PathUtils.envPath()
+
+    assertArrayIncludes(envPath, [Path.root.join("usr/bin")])
+
+    const a = Path.home().join("tmp/bin")
+    const b = PathUtils.addPath(a)
+    assertArrayIncludes(b, [a])
+
+    const c = PathUtils.envPath()
+    assertArrayIncludes(c, [a])
+
+    const d = PathUtils.rmPath(a)
+    assertEquals(d, envPath)
+
+    const e = PathUtils.envPath()
+    assertEquals(e, envPath)
+  })
+
+  await test.step("search $PATH", () => {
+    const usrBin = Path.root.join("usr/bin")
+    const bin = Path.root.join("bin")
+    const sbin = Path.root.join("sbin")
+    const envPath = PathUtils.envPath()
+
+    assertArrayIncludes(envPath, [usrBin])
+
+    const a = PathUtils.findBinary("env", envPath)
+    assertEquals(a, usrBin.join("env"))
+
+    const b = PathUtils.findBinary("env")
+    assertEquals(b, usrBin.join("env"))
+
+    const c = PathUtils.findBinary("bloogargle", envPath)
+    assertEquals(c, undefined)
+
+    const d = PathUtils.findBinary("ls", [bin])
+    assertEquals(d, bin.join("ls"))
+
+    const e = PathUtils.findBinary("ls", [sbin])
+    assertEquals(e, undefined)
+  })
+})


### PR DESCRIPTION
if this is out-of-scope, feel free to close. felt like a _common_ path function, on par with `home()`.