### PR TITLE
dark magic v0.3.0: brew

### DIFF
--- a/src/hooks/useDarkMagic.ts
+++ b/src/hooks/useDarkMagic.ts
@@ -1,6 +1,7 @@
 import { Range } from "semver"
 import { useFetch, usePrefix } from "hooks"
 import { WhichResult } from "types"
+import PathUtils from "path-utils"
 
 export default function useDarkMagic() {
   return { which }
@@ -12,6 +13,7 @@ const which = async (arg0: string | undefined): Promise<WhichResult | undefined>
     npx(arg0),
     pipx(arg0),
     cargo(arg0),
+    brew(arg0),
   ])
 
   // Return the first non-empty result
@@ -64,6 +66,24 @@ const cargo = async (arg0: string | undefined) => {
         binDir.parent().string, // installs to {root}/bin
         arg0!,
       ]
+    }
+  }
+
+  return undefined
+}
+
+const brew = async (arg0: string | undefined) => {
+  if (!PathUtils.findBinary("brew")) return undefined
+
+  const res = await useFetch(`https://formulae.brew.sh/api/formula/${arg0}.json`)
+
+  if (res.status == 200) {
+    return {
+      // FIXME: we should package brew; in the interim
+      // we have to return a WhichResult with a project
+      project: "tea.xyz",
+      constraint: new Range("*"),
+      precmd: ["brew", "install", arg0!]
     }
   }
 

--- a/src/hooks/useDarkMagic.ts
+++ b/src/hooks/useDarkMagic.ts
@@ -72,6 +72,12 @@ const cargo = async (arg0: string | undefined) => {
   return undefined
 }
 
+// Installs will also end up outside tea's prefix, so they won't be removed by
+// uninstall. So maybe this is fine?
+
+// also FIXME: once you _execute_ brew install, `--provides` returns false,
+// since it's in the path at that point. But I doubt uninstalling after
+// run is the right answer.
 const brew = async (arg0: string | undefined) => {
   if (!PathUtils.findBinary("brew")) return undefined
 

--- a/src/hooks/useExec.ts
+++ b/src/hooks/useExec.ts
@@ -94,7 +94,7 @@ export default async function({ pkgs, inject, sync, ...opts }: Parameters) {
       if (found.precmd) {
         // FIXME: this is a weird one. It could take _minutes_ to install something
         // (though ctrl-c works, as long as you're not in docker). That's a little
-        // less magical, but for installs they should only run one time. 
+        // less magical, but for installs they should only run one time.
         await useRun({ cmd: found.precmd })
       }
     }

--- a/tests/functional/provides.test.ts
+++ b/tests/functional/provides.test.ts
@@ -46,7 +46,9 @@ Deno.test("provides", { sanitizeResources: false, sanitizeOps: false }, async te
     await assertRejects(() => run(["--provides", "so_stupid_search"]), ExitError, "exiting with code: 0")
   })
 
-  // Same install issue as above.
+  // FIXME: once you _execute_ brew install, `--provides` returns false,
+  // since it's in the path at that point. But I doubt uninstalling after
+  // run is the right answer.
   await test.step("dark magic provides -- brew install php-cs-fixer", async () => {
     // FIXME: package brew.sh
     if (!PathUtils.findBinary("brew")) return

--- a/tests/functional/provides.test.ts
+++ b/tests/functional/provides.test.ts
@@ -1,5 +1,6 @@
 import { assertRejects } from "deno/testing/asserts.ts"
 import { ExitError } from "types"
+import PathUtils from "path-utils"
 import { createTestHarness } from "./testUtils.ts"
 
 Deno.test("provides", { sanitizeResources: false, sanitizeOps: false }, async test => {
@@ -43,5 +44,13 @@ Deno.test("provides", { sanitizeResources: false, sanitizeOps: false }, async te
   await test.step("dark magic provides -- cargo install so_stupid_search", async () => {
     const { run } = await createTestHarness()
     await assertRejects(() => run(["--provides", "so_stupid_search"]), ExitError, "exiting with code: 0")
+  })
+
+  // Same install issue as above.
+  await test.step("dark magic provides -- brew install php-cs-fixer", async () => {
+    // FIXME: package brew.sh
+    if (!PathUtils.findBinary("brew")) return
+    const { run } = await createTestHarness()
+    await assertRejects(() => run(["--provides", "php-cs-fixer"]), ExitError, "exiting with code: 0")
   })
 })


### PR DESCRIPTION
this uses `Path.findBin()` to test for a `brew` install (we should package brew, probably). If that PR is rejected, then we'll need a new plan.