### PR TITLE
fix behavior of `^` in pre-1.0 semver

### DIFF
--- a/src/utils/semver.ts
+++ b/src/utils/semver.ts
@@ -137,9 +137,9 @@ export class Range {
             v1 = new SemVer(match[2], {tolerant: true})
             const parts = []
             for (let i = 0; i < v1.components.length; i++) {
-              if (v1.components[i] === 0) {
+              if (v1.components[i] === 0 && i < v1.components.length - 1) {
                 parts.push(0)
-              } else if (v1.components[i] > 0) {
+              } else {
                 parts.push(v1.components[i] + 1)
                 break
               }

--- a/src/utils/semver.ts
+++ b/src/utils/semver.ts
@@ -132,9 +132,19 @@ export class Range {
         } else if ((match = input.match(/^([~=<^])(.+)$/))) {
           let v1: SemVer | undefined, v2: SemVer | undefined
           switch (match[1]) {
+          // deno-lint-ignore no-case-declarations
           case "^":
             v1 = new SemVer(match[2], {tolerant: true})
-            v2 = new SemVer([v1.major + 1], {tolerant: true})
+            const parts = []
+            for (let i = 0; i < v1.components.length; i++) {
+              if (v1.components[i] === 0) {
+                parts.push(0)
+              } else if (v1.components[i] > 0) {
+                parts.push(v1.components[i] + 1)
+                break
+              }
+            }
+            v2 = new SemVer(parts, {tolerant: true})
             return [v1, v2]
           case "~": {
             v1 = new SemVer(match[2], {tolerant: true})

--- a/tests/unit/semver.test.ts
+++ b/tests/unit/semver.test.ts
@@ -114,6 +114,14 @@ Deno.test("semver", async test => {
     assert(l.satisfies(new SemVer("0.0.0.1")))
     assertFalse(l.satisfies(new SemVer("0.0.0.2")))
 
+    // This one is weird, but it should mean "<1"
+    const m = new semver.Range("^0")
+    assert(m.satisfies(new SemVer("0.0.0")))
+    assert(m.satisfies(new SemVer("0.0.1")))
+    assert(m.satisfies(new SemVer("0.1.0")))
+    assert(m.satisfies(new SemVer("0.9.1")))
+    assertFalse(m.satisfies(new SemVer("1.0.0")))
+
     assertThrows(() => new semver.Range("1"))
     assertThrows(() => new semver.Range("1.2"))
     assertThrows(() => new semver.Range("1.2.3"))

--- a/tests/unit/semver.test.ts
+++ b/tests/unit/semver.test.ts
@@ -51,7 +51,10 @@ Deno.test("semver", async test => {
     assertFalse(a.satisfies(new SemVer("2.5.0")))
 
     const b = new semver.Range("^0.15")
-    assertEquals(b.toString(), "^0.15")
+    // Due to the nature of the `^` operator, this
+    // is the same as `~0.15`, and our code represents
+    // it as such.
+    assertEquals(b.toString(), "~0.15")
 
     const c = new semver.Range("~0.15")
     assertEquals(c.toString(), "~0.15")
@@ -94,6 +97,22 @@ Deno.test("semver", async test => {
     assert(i.satisfies(new SemVer("1.2.4.2")))
     assert(i.satisfies(new SemVer("1.3.4.2")))
     assertFalse(i.satisfies(new SemVer("2.0.0")))
+
+    const j = new semver.Range("^0.1.2.3")
+    assert(j.satisfies(new SemVer("0.1.2.3")))
+    assert(j.satisfies(new SemVer("0.1.3")))
+    assertFalse(j.satisfies(new SemVer("0.2.0")))
+
+    const k = new semver.Range("^0.0.1.2")
+    assertFalse(k.satisfies(new SemVer("0.0.1.1")))
+    assert(k.satisfies(new SemVer("0.0.1.2")))
+    assert(k.satisfies(new SemVer("0.0.1.9")))
+    assertFalse(k.satisfies(new SemVer("0.0.2.0")))
+
+    const l = new semver.Range("^0.0.0.1")
+    assertFalse(l.satisfies(new SemVer("0.0.0.0")))
+    assert(l.satisfies(new SemVer("0.0.0.1")))
+    assertFalse(l.satisfies(new SemVer("0.0.0.2")))
 
     assertThrows(() => new semver.Range("1"))
     assertThrows(() => new semver.Range("1.2"))


### PR DESCRIPTION
ref: https://github.com/teaxyz/cli/issues/473#issuecomment-1498925758
ref: https://github.com/jhheider/semverator/commit/7d8ae450a5a2af91256c99273797cf9eed0948c1