### PR TITLE
Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,6 @@ $ cd tea
 
 deno task run foo
 # ^^ runs the local checkout passing `foo` as an argument
-# NOTE this doesn't currently work due (our bug)
 
 $ deno task install
 # ^^ deploys the local checkout into your `~/.tea`

--- a/src/args.ts
+++ b/src/args.ts
@@ -35,6 +35,7 @@ export function parseArgs(args: string[], arg0: string): [Args, Flags, Error?] {
       ? target.basename()
       : link.basename()
     const match = base.match(/^tea[_+]([^\/]+)$/)
+    if (link.basename() == "deno" && !link.isSymlink()) return  // deno is literally executing our source code
     args = [match?.[1] ?? base, ...args]
   })()
 

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -32,3 +32,13 @@ it(suite, "tea /bin/ls", async function() {
   const out = await this.run({ args: ["/bin/ls", "foo"] }).stdout()
   assertEquals(out, "bar\n")
 })
+
+it(suite, "tea chalk --version (via npx provider)", async function() {
+  this.sandbox.join("foo").mkdir().join("bar").touch()
+  await this.run({ args: ["chalk", "--version"] })
+})
+
+it(suite, "tea http-server --help (via npx provider)", async function() {
+  this.sandbox.join("foo").mkdir().join("bar").touch()
+  await this.run({ args: ["http-server", "--help"] })
+})


### PR DESCRIPTION
This enables magic for eg. `kill-port 7680` to execute via `npx` based on this being added to the pantry under `npmjs.com/provider.yml`.

We insist on things that we magically execute being vetted to the order of being in the pantry.