### PR TITLE
Add debug configuration for running cli in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,21 @@
     "version": "0.2.0",
     "configurations": [
         {
+          "request": "launch",
+          "name": "Debug Command",
+          "type": "node",
+          "cwd": "${workspaceFolder}",
+          "runtimeExecutable": "deno",
+          "runtimeArgs": [
+            "run",
+            "--inspect-brk",
+            "-A",
+            "${workspaceFolder}/src/app.ts",
+            "python@3"
+          ],
+          "attachSimplePort": 9229
+        },
+        {
             "request": "launch",
             "name": "Debug Test",
             "type": "node",

--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ $ deno task install
 $ deno task compile && ./tea
 ```
 
+## Visual Studio Code
+
+<!-- TODO: Add some info -->
+
+* Install [deno vscode extension](TODO: add link)
+* Install deno via homebrew?
+
 
 [docs.tea.xyz]: https://docs.tea.xyz
 [deno]: https://deno.land

--- a/src/args.ts
+++ b/src/args.ts
@@ -35,7 +35,10 @@ export function parseArgs(args: string[], arg0: string): [Args, Flags, Error?] {
       ? target.basename()
       : link.basename()
     const match = base.match(/^tea[_+]([^\/]+)$/)
-    if (link.basename() == "deno" && !link.isSymlink()) return  // deno is literally executing our source code
+    const basename = link.basename()
+    // const isSymlink = link.isSymlink()
+    if (basename == "deno") return
+    // if (basename == "deno" && !isSymlink) return  // deno is literally executing our source code
     args = [match?.[1] ?? base, ...args]
   })()
 


### PR DESCRIPTION
I didn't see anything in the docs about how to debug run in vscode so I messed around a bit and got it kind of working. For some reason it adds `deno` as an arg and the symlink check makes it get appended which causes problems. I'm not sure what the current symlink check is for, so could use some guidance there. It seems to hang and never finish, but I haven't looked into that yet.