### PR TITLE
Remove tolerant option from Semver

### DIFF
--- a/src/utils/semver.ts
+++ b/src/utils/semver.ts
@@ -21,12 +21,11 @@ export default class SemVer {
   readonly raw: string
   readonly pretty?: string
 
-  constructor(input: string | number[] | Range | SemVer, {tolerant}: {tolerant: boolean} = {tolerant: false}) {
+  constructor(input: string | number[] | Range | SemVer) {
     if (typeof input == 'string') {
       const vprefix = input.startsWith('v')
       const raw = vprefix ? input.slice(1) : input
       const parts = raw.split('.')
-      if (parts.length < 3 && !vprefix && !tolerant) throw new Error(`too short to parse without a \`v\` prefix: ${input}`)
       let pretty_is_raw = false
       this.components = parts.flatMap((x, index) => {
         const match = x.match(/^(\d+)([a-z])$/)
@@ -102,7 +101,7 @@ export default class SemVer {
 /// also slightly more tolerant parsing
 export function parse(input: string) {
   try {
-    return new SemVer(input, {tolerant: true})
+    return new SemVer(input)
   } catch {
     return undefined
   }
@@ -126,15 +125,15 @@ export class Range {
       this.set = input.split(/(?:,|\s*\|\|\s*)/).map(input => {
         let match = input.match(/^>=((\d+\.)*\d+)\s*(<((\d+\.)*\d+))?$/)
         if (match) {
-          const v1 = new SemVer(match[1], {tolerant: true})
-          const v2 = match[3] ? new SemVer(match[4], {tolerant: true})! : new SemVer([Infinity, Infinity, Infinity])
+          const v1 = new SemVer(match[1])
+          const v2 = match[3] ? new SemVer(match[4])! : new SemVer([Infinity, Infinity, Infinity])
           return [v1, v2]
         } else if ((match = input.match(/^([~=<^])(.+)$/))) {
           let v1: SemVer | undefined, v2: SemVer | undefined
           switch (match[1]) {
           // deno-lint-ignore no-case-declarations
           case "^":
-            v1 = new SemVer(match[2], {tolerant: true})
+            v1 = new SemVer(match[2])
             const parts = []
             for (let i = 0; i < v1.components.length; i++) {
               if (v1.components[i] === 0 && i < v1.components.length - 1) {
@@ -144,23 +143,23 @@ export class Range {
                 break
               }
             }
-            v2 = new SemVer(parts, {tolerant: true})
+            v2 = new SemVer(parts)
             return [v1, v2]
           case "~": {
-            v1 = new SemVer(match[2], {tolerant: true})
+            v1 = new SemVer(match[2])
             if (v1.components.length == 1) {
               // yep this is the official policy
-              v2 = new SemVer([v1.major + 1], {tolerant: true})
+              v2 = new SemVer([v1.major + 1])
             } else {
-              v2 = new SemVer([v1.major, v1.minor + 1], {tolerant: true})
+              v2 = new SemVer([v1.major, v1.minor + 1])
             }
           } return [v1, v2]
           case "<":
-            v1 = new SemVer([0], {tolerant: true})
-            v2 = new SemVer(match[2], {tolerant: true})
+            v1 = new SemVer([0])
+            v2 = new SemVer(match[2])
             return [v1, v2]
           case "=":
-            return new SemVer(match[2], {tolerant: true})
+            return new SemVer(match[2])
           }
         }
         throw err()

--- a/tests/unit/semver.test.ts
+++ b/tests/unit/semver.test.ts
@@ -35,6 +35,10 @@ Deno.test("semver", async test => {
     assertEquals(new SemVer("1").toString(), "1.0.0")
     assertEquals(new SemVer("v1").toString(), "1.0.0")
 
+    assertEquals(new SemVer("9e").toString(), "9e")
+    assertEquals(new SemVer("9e").components, [9,5])
+    assertEquals(new SemVer("3.3a").toString(), "3.3a")
+    assertEquals(new SemVer("3.3a").components, [3,3,1])
     assertEquals(new SemVer("1.1.1q").toString(), "1.1.1q")
     assertEquals(new SemVer("1.1.1q").components, [1,1,1,17])
   })

--- a/tests/unit/semver.test.ts
+++ b/tests/unit/semver.test.ts
@@ -30,9 +30,9 @@ Deno.test("semver", async test => {
     assertEquals(new SemVer("1.2.3.4").toString(), "1.2.3.4")
     assertEquals(new SemVer("1.2.3").toString(), "1.2.3")
     assertEquals(new SemVer("v1.2.3").toString(), "1.2.3")
-    assertThrows(() => new SemVer("1.2"))
+    assertEquals(new SemVer("1.2").toString(), "1.2.0")
     assertEquals(new SemVer("v1.2").toString(), "1.2.0")
-    assertThrows(() => new SemVer("1"))
+    assertEquals(new SemVer("1").toString(), "1.0.0")
     assertEquals(new SemVer("v1").toString(), "1.0.0")
 
     assertEquals(new SemVer("1.1.1q").toString(), "1.1.1q")


### PR DESCRIPTION
Uploaded bottles versions are always checked with Semver with tolerant=true.
Therefore, CLI also has to accept SemVer objects with tolerant=true, I think it meens that tolerant option doesn't be needed.

This PR remove the tolerant option from SemVer.
I confirmed local tests are all passed and tmux=3.3a can be run.

<details>

<summary>test resulsts</summary>

```sh
$ deno task test
Task test deno test --allow-net --allow-read --allow-env --allow-run --allow-write --unstable
Check file:///home/uesyn/src/github.com/uesyn/cli/tests/functional/args.test.ts
Check file:///home/uesyn/src/github.com/uesyn/cli/tests/functional/devenv.test.ts
Check file:///home/uesyn/src/github.com/uesyn/cli/tests/functional/exec.test.ts
Check file:///home/uesyn/src/github.com/uesyn/cli/tests/functional/magic.test.ts
Check file:///home/uesyn/src/github.com/uesyn/cli/tests/functional/provides.test.ts
Check file:///home/uesyn/src/github.com/uesyn/cli/tests/functional/repl.test.ts

...

<<----------------------------------------------------- attachment end
----- output end -----
  normal error ... ok (4ms)
useErrorHandler ... ok (20ms)
useErrorHandler silent ...
  normal error ... ok (4ms)
useErrorHandler silent ... ok (8ms)
running 6 tests from ./tests/unit/utils.test.ts
validate string ... ok (5ms)
validate array ... ok (2ms)
flatmap ... ok (3ms)
async flatmap ... ok (3ms)
chuzzle ... ok (3ms)
panic ... ok (4ms)
                                                                                                                                                                                              
ok | 53 passed (159 steps) | 0 failed (2m35s)
```

</details>

<details>

<summary>tmux</summary>

```
$ export TEA_PREFIX=${HOME}/.tea
$ rm -rf $TEA_PREFIX                                                                                                                                                                          $ ./tea --version
tea 0.31.2+dev                                                                                                                                                                                  
$ ./tea -S
pantries sync’d ⎷
tea: empty pkg env
$ ./tea +github.com/tmux/tmux=3.3a tmux -V                                                                                                                                                   installed: ~/.tea/curl.se/ca-certs/v2023.1.10
installed: ~/.tea/openssl.org/v1.1.1t
installed: ~/.tea/libevent.org/v2.1.12
installed: ~/.tea/invisible-island.net/ncurses/v6.4.0
installed: ~/.tea/github.com/tmux/tmux/v3.3a
tmux 3.3a 
```

</details>

fix: https://github.com/teaxyz/cli/issues/572