### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,9 +37,9 @@ jobs:
           git fetch --prune --unshallow --tags
 
           if git show-ref --tags v${{ steps.tea.outputs.version }} --quiet; then
-            echo "::set-output name=result::cancel"
+            echo "result=cancel" >> $GITHUB_OUTPUT;;
           else
-            echo "::set-output name=result::commence"
+            echo "result=commence" >> $GITHUB_OUTPUT;;
           fi
 
       - uses: andymckay/cancel-action@0.2


### PR DESCRIPTION
## Description

Resolve  #575 

Update `.github/workflows/cd.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=result::cancel"
```

```yml
echo "::set-output name=result::commence"
```

**TO-BE**

```yml
echo "result=cancel" >> $GITHUB_OUTPUT;;
```

```yml
echo "result=commence" >> $GITHUB_OUTPUT;;
```