### PR TITLE
Typo: remove duplicated --dry-run in --help

### DIFF
--- a/src/app.help.ts
+++ b/src/app.help.ts
@@ -46,7 +46,6 @@ export default async function help(verbosity = Verbosity.normal) {
         --silent,-s              no chat, no errors: only output the requested data
         --cd,-C,--chdir <dir>    change directory first
         --chaste                 abstain from networking, installing packages, etc.
-        --dry-run,-n             don’t execute, just print
 
         • repetitions override previous values
         • long form boolean flags can be assigned, eg. --env=no


### PR DESCRIPTION
The current verbose help has this list of flags:

```
flags:
[...]
  --dry-run,-n             don’t do anything, just print
[...]
  --dry-run,-n             don’t execute, just print
```

Which has the `--dry-run` flag duplicated. This commit removes the second instance. Since the wording was slightly different for each of the instances, I kept the wording and the ordering as is used for the "less verbose" version of `--help`, which looks like:

```
flags:
  --sync,-S       sync and update environment packages
  --env,-E        inject local environment
  --dry-run,-n    don’t do anything, just print
```