### PR TITLE
auto symlink ~/.tea/local/bin/foo on installs

### DIFF
--- a/src/app.main.ts
+++ b/src/app.main.ts
@@ -1,10 +1,11 @@
-import { usePrefix, useExec, useVirtualEnv, useVersion, usePrint, useConfig, useLogger } from "hooks"
+import { usePrefix, useVirtualEnv, useVersion, usePrint, useConfig, useLogger } from "hooks"
 import { VirtualEnv } from "./hooks/useVirtualEnv.ts"
 import { Verbosity } from "./hooks/useConfig.ts"
 import { Path, utils, semver, hooks } from "tea"
 import { basename } from "deno/path/mod.ts"
 import exec, { repl } from "./app.exec.ts"
 import provides from "./app.provides.ts"
+import setup from "./prefab/setup.ts"
 import magic from "./app.magic.ts"
 import dump from "./app.dump.ts"
 import help from "./app.help.ts"
@@ -46,7 +47,7 @@ export async function run(args: Args) {
     const wut_ = wut(args)
 
     const venv = await injection(args)
-    const {cmd, env, pkgs, installations} = await useExec({...args, inject: venv})
+    const {cmd, env, pkgs, installations} = await setup({...args, inject: venv})
 
     const full_path = () => [...env["PATH"]?.split(':') ?? [], ...PATH?.split(':') ?? []].uniq()
 

--- a/src/app.provides.ts
+++ b/src/app.provides.ts
@@ -1,5 +1,5 @@
 import { ExitError } from "./hooks/useErrorHandler.ts"
-import { which } from "./hooks/useExec.ts"
+import which from "tea/plumbing/which.ts"
 
 export default async function provides(args: string[]) {
   let status = 0;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,7 +1,5 @@
-
-import useExec from "./useExec.ts"
-import useVirtualEnv from "./useVirtualEnv.ts"
-import usePackageYAML, { usePackageYAMLFrontMatter } from "./usePackageYAML.ts"
+import useVirtualEnv, { VirtualEnv } from "./useVirtualEnv.ts"
+import useYAMLFrontMatter from "./useYAMLFrontMatter.ts"
 import useVersion from "./useVersion.ts"
 import useErrorHandler, { ExitError } from "./useErrorHandler.ts"
 import usePrint from "./usePrint.ts"
@@ -14,10 +12,8 @@ function usePrefix() {
 }
 
 export {
-  useExec,
   useVirtualEnv,
-  usePackageYAML,
-  usePackageYAMLFrontMatter,
+  useYAMLFrontMatter,
   useVersion,
   useErrorHandler,
   usePrint,
@@ -30,7 +26,7 @@ export {
   ExitError
 }
 
-export type { RunOptions }
+export type { RunOptions, VirtualEnv }
 
 declare global {
   interface Array<T> {

--- a/src/hooks/useVersion.ts
+++ b/src/hooks/useVersion.ts
@@ -1,3 +1,5 @@
+//NOTE we statically replace this file at deployment
+
 import { README } from "./useVirtualEnv.ts"
 import { Path } from "tea"
 
@@ -11,5 +13,3 @@ const version = `${(
 export default function() {
   return version
 }
-
-// we statically replace this file at deployment

--- a/src/hooks/useVirtualEnv.ts
+++ b/src/hooks/useVirtualEnv.ts
@@ -1,4 +1,4 @@
-import { usePackageYAMLFrontMatter, refineFrontMatter, FrontMatter } from "./usePackageYAML.ts"
+import usePackageYAMLFrontMatter, { refineFrontMatter, FrontMatter } from "./useYAMLFrontMatter.ts"
 import { PackageRequirement, Path, SemVer, utils, TeaError, hooks, semver } from "tea"
 const { flatmap, pkg, validate } = utils
 import { isPlainObject } from "is-what"

--- a/src/hooks/useYAMLFrontMatter.ts
+++ b/src/hooks/useYAMLFrontMatter.ts
@@ -4,12 +4,26 @@ const { validatePackageRequirement } = hacks
 const { useMoustaches, useConfig } = hooks
 const { validate } = utils
 
+export interface FrontMatter {
+  args: string[]
+  pkgs: PackageRequirement[]
+  env: Record<string, string>
+}
+
+export default async function(script: Path, srcroot?: Path): Promise<FrontMatter | undefined> {
+  const yaml = await readYAMLFrontMatter(script)
+  if (!yaml) return
+  return refineFrontMatter(yaml, srcroot)
+}
+
+
+
 interface Return1 {
   getDeps: (wbuild: boolean) => PackageRequirement[]
   yaml: PlainObject
 }
 
-export default function usePackageYAML(yaml: unknown): Return1 {
+function parseYAMLFrontMatter(yaml: unknown): Return1 {
   //TODO do magic: if (err == "no-front-matter")
 
   if (!isPlainObject(yaml)) throw new Error("bad-yaml")
@@ -28,14 +42,8 @@ export default function usePackageYAML(yaml: unknown): Return1 {
   return { getDeps, yaml }
 }
 
-export interface FrontMatter {
-  args: string[]
-  pkgs: PackageRequirement[]
-  env: Record<string, string>
-}
-
 export function refineFrontMatter(obj: unknown, srcroot?: Path): FrontMatter {
-  const rv = usePackageYAML(obj)
+  const rv = parseYAMLFrontMatter(obj)
 
   const getArgs = () => {
     const fn1 = () => {
@@ -78,14 +86,7 @@ export function refineFrontMatter(obj: unknown, srcroot?: Path): FrontMatter {
   }
 }
 
-export async function usePackageYAMLFrontMatter(script: Path, srcroot?: Path): Promise<FrontMatter | undefined> {
-  const yaml = await readYAMLFrontMatter(script)
-  if (!yaml) return
-  return refineFrontMatter(yaml, srcroot)
-}
-
-
-import { parse as parseYaml } from "https://deno.land/std@0.182.0/encoding/yaml.ts"
+import { parse as parseYaml } from "https://deno.land/std@0.190.0/yaml/parse.ts"
 import { readLines } from "deno/io/read_lines.ts"
 
 async function readYAMLFrontMatter(path: Path): Promise<PlainObject | undefined> {

--- a/tests/functional/run.test.ts
+++ b/tests/functional/run.test.ts
@@ -88,3 +88,8 @@ Deno.test("usage error", async () => {
   const { run } = await createTestHarness()
   assertRejects(() => run(["--invalid-option"]))
 })
+
+Deno.test("tea commands", async () => {
+  const { run } = await createTestHarness()
+  await run(["pkg", "query", "--prefix", "zlib.net=1"])
+})

--- a/tests/integration/tea.ln.test.ts
+++ b/tests/integration/tea.ln.test.ts
@@ -69,3 +69,11 @@ it(suite, "hardlinks work", async function() {
   const out = await run(['node', "--eval", "console.log('hello')"], node.parent(), this.TEA_PREFIX)
   assertEquals(out, "hello\n", out)
 })
+
+it(suite, "auto-symlinks in ~/.tea/local work", async function() {
+  /// this functionality only works for properly installed tea/cli installations
+  this.tea = this.tea.cp({ into: this.TEA_PREFIX.join("tea.xyz/v*/bin").mkdir('p') })
+  await this.run({args: ["perl", "--version"]})
+
+  assert(this.TEA_PREFIX.join("local/bin/perl").isExecutableFile())
+})


### PR DESCRIPTION
it’s always symlinked to v* so it can only be the latest version. This suits what most people want this feature for.

Refs #600