### PR TITLE
zsh autocomplete

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
   "deno.config": "deno.jsonc",
   "markdownlint.config": {
     "extends": "./.github/markdownlint.yml"
-  }
+  },
+  "editor.formatOnSaveMode": "modificationsIfAvailable"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,5 @@
   "deno.config": "deno.jsonc",
   "markdownlint.config": {
     "extends": "./.github/markdownlint.yml"
-  },
-  "editor.formatOnSaveMode": "modificationsIfAvailable"
+  }
 }

--- a/src/app.complete.ts
+++ b/src/app.complete.ts
@@ -1,0 +1,21 @@
+import { usePrint } from "hooks"
+import { hooks } from "tea"
+const { usePantry } = hooks
+
+export default async function complete(prefix: string | undefined) {
+  if (!prefix) return
+
+  const pantry = usePantry()
+  const { print } = usePrint()
+
+  const completions = new Set<string>()
+
+  for await (const project of pantry.ls()) {
+    const provides = await pantry.project(project).provides()
+    for (const bin of provides) {
+      if (bin.startsWith(prefix)) completions.add(bin)
+    }
+  }
+
+  if (completions.size) await print([...completions].sort().join('\n'))
+}

--- a/src/app.complete.ts
+++ b/src/app.complete.ts
@@ -13,7 +13,8 @@ export default async function complete(prefix: string | undefined) {
   for await (const project of pantry.ls()) {
     const provides = await pantry.project(project).provides()
     for (const bin of provides) {
-      if (bin.startsWith(prefix)) completions.add(bin)
+      // Exclude matching moustaches for sanity
+      if (bin.startsWith(prefix) && !bin.match(/{{.*}}/)) completions.add(bin)
     }
   }
 

--- a/src/app.help.ts
+++ b/src/app.help.ts
@@ -54,9 +54,10 @@ export default async function help(verbosity = Verbosity.normal) {
 
       alt. modes:
         --help,-h
-        --version,-v      prints tea’s version
-        --prefix          prints the tea prefix ‡
-        --provides        exits successfully if package/s are provided
+        --version,-v         prints tea’s version
+        --prefix             prints the tea prefix ‡
+        --complete <prefix>  generates autocompletions for possible binary names
+        --provides           exits successfully if package/s are provided
 
         ‡ all packages are “stowed” in the tea prefix, eg. ~/.tea/rust-lang.org/v1.65.0
 

--- a/src/app.magic.ts
+++ b/src/app.magic.ts
@@ -56,23 +56,30 @@ export default function(self: Path, shell?: string) {
         fi
       }
 
-      _tea_completion() {
+      function _tea_completion {
         local completions
 
         if _has_tea_magic; then
           # Call \`tea --complete\` with the current word as the prefix
           completions=($(tea --complete \${words[CURRENT]}))
-          compadd "$completions[@]"
+          if [[ -n "\${completions}" ]]; then
+            _describe "tea" completions
+          fi
         fi
+      }
 
-        # Run the default completions no matter what
-        _complete
+      function _tea_command_names {
+        _tea_completion "$@"
+        _command_names
+      }
+
+      function _tea_completion_wrapper {
+        _tea_command_names "$@"
       }
 
       autoload -Uz compinit
       compinit
-
-      zstyle ':completion:*' completer _tea_completion
+      compdef _tea_completion_wrapper -command-
       `;
   case "elvish":
     // eval ($MAGIC | slurp)

--- a/src/app.magic.ts
+++ b/src/app.magic.ts
@@ -60,8 +60,8 @@ export default function(self: Path, shell?: string) {
         local completions
 
         if _has_tea_magic; then
-          # Call \`tea --autocomplete\` with the current word as the prefix
-          completions=($(tea --autocomplete \${words[CURRENT]}))
+          # Call \`tea --complete\` with the current word as the prefix
+          completions=($(tea --complete \${words[CURRENT]}))
           compadd "$completions[@]"
         fi
 

--- a/src/app.magic.ts
+++ b/src/app.magic.ts
@@ -43,15 +43,37 @@ export default function(self: Path, shell?: string) {
         export PATH="${d}:$PATH"
       fi
 
+      _has_tea_magic() {
+        [ "\${TEA_MAGIC:-}" != 0 -a -x "${d}"/tea ]
+      }
+
       function command_not_found_handler {
-        if [ "\${TEA_MAGIC:-}" != 0 -a -x "${d}"/tea ]; then
+        if _has_tea_magic; then
           TEA_MAGIC="abracadabra:$TEA_MAGIC" "${d}"/tea -- $*
         else
           echo "zsh: command not found: $*" >&2
           exit 127
         fi
       }
-      `
+
+      _tea_completion() {
+        local completions
+
+        if _has_tea_magic; then
+          # Call \`tea --autocomplete\` with the current word as the prefix
+          completions=($(tea --autocomplete \${words[CURRENT]}))
+          compadd "$completions[@]"
+        fi
+
+        # Run the default completions no matter what
+        _complete
+      }
+
+      autoload -Uz compinit
+      compinit
+
+      zstyle ':completion:*' completer _tea_completion
+      `;
   case "elvish":
     // eval ($MAGIC | slurp)
     return undent`

--- a/src/app.main.ts
+++ b/src/app.main.ts
@@ -4,6 +4,7 @@ import { Verbosity } from "./hooks/useConfig.ts"
 import { Path, utils, semver, hooks } from "tea"
 import { basename } from "deno/path/mod.ts"
 import exec, { repl } from "./app.exec.ts"
+import complete from "./app.complete.ts"
 import provides from "./app.provides.ts"
 import setup from "./prefab/setup.ts"
 import magic from "./app.magic.ts"
@@ -102,6 +103,9 @@ export async function run(args: Args) {
     break
   case "provides":
     await provides(args.args)
+    break
+  case "complete":
+    await complete(args.complete)
     break
   default:
     await print(magic(execPath, args.mode[1]))

--- a/src/args.ts
+++ b/src/args.ts
@@ -3,12 +3,13 @@ const { pkg, validate } = utils
 
 export type Args = {
   cd?: Path
-  mode: 'std' | 'help' | 'version' | 'prefix' | ['magic', string | undefined] | 'provides'
+  mode: 'std' | 'help' | 'version' | 'prefix' | ['magic', string | undefined] | 'provides' | 'complete'
   sync: boolean
   args: string[]
   pkgs: PackageSpecification[]
   inject?: boolean
   chaste: boolean
+  complete?: string
 }
 
 export interface Flags {
@@ -120,6 +121,10 @@ export function parseArgs(args: string[], arg0: string): [Args, Flags, Error?] {
       case 'provides':
         nonovalue()
         rv.mode = 'provides'
+        break
+      case 'complete':
+        rv.complete = value ?? it.next().value ?? barf()
+        rv.mode = key
         break
       case 'keep-going':
         flags.keepGoing = parseBool(value ?? "yes") ?? barf()

--- a/tests/functional/run.test.ts
+++ b/tests/functional/run.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertRejects } from "deno/testing/asserts.ts"
+import { assert, assertEquals, assertRejects, assertArrayIncludes } from "deno/testing/asserts.ts"
 import { createTestHarness } from "./testUtils.ts"
 
 Deno.test("env", { sanitizeResources: false, sanitizeOps: false }, async () => {
@@ -39,6 +39,32 @@ Deno.test("version", { sanitizeResources: false, sanitizeOps: false }, async () 
 
   assert(stdout.length > 0, "lines should have printed")
   assert(stdout[0].startsWith("tea"))
+})
+
+Deno.test("complete node", { sanitizeResources: false, sanitizeOps: false }, async () => {
+  const {run } = await createTestHarness()
+
+  const { stdout } = await run(["--complete", "node"])
+
+  assert(stdout.length > 0, "lines should have printed")
+  assertArrayIncludes(stdout[0].split("\n"), ["node"])
+})
+
+Deno.test("complete no", { sanitizeResources: false, sanitizeOps: false }, async () => {
+  const {run } = await createTestHarness()
+
+  const { stdout } = await run(["--complete", "no"])
+
+  assert(stdout.length > 0, "lines should have printed")
+  assertArrayIncludes(stdout[0].split("\n"), ["node", "nohup"])
+})
+
+Deno.test("complete brazzorsks", { sanitizeResources: false, sanitizeOps: false }, async () => {
+  const {run } = await createTestHarness()
+
+  const { stdout } = await run(["--complete", "brazzorsks"])
+
+  assert(stdout.length == 0, "no lines should have printed")
 })
 
 Deno.test("help", { sanitizeResources: false, sanitizeOps: false }, async () => {


### PR DESCRIPTION
This works. The places I think it might need love:
- it will be slow. and ever slower. useSync should cache all the provides to the sqlite store for much faster performance.
- ~it wasn't in any way clear to me how to interleave our completions with zsh's defaults. possibly because we don't work like anything else~
  - ~one possibility is to do the path scanning ourselves, so we can just do the whole completion stack. this will also take time, and want for caching.~