### PR TITLE
tea help typo: fix "an containerized"

### DIFF
--- a/src/app.help.ts
+++ b/src/app.help.ts
@@ -15,7 +15,7 @@ export default async function help(verbosity = Verbosity.normal) {
   05    $ tea node^19 --eval 'console.log("tea.xyz")'
         $ tea +nodejs.org man node
         $ tea +bun.sh sh
-        # ^^ try out bun in an containerized shell
+        # ^^ try out bun in a containerized shell
 
   10  flags:
         --sync,-S       sync and update environment packages


### PR DESCRIPTION
In `tea --help`, "an containerized" shuould be "a containerized".

Thx to @rohanssrao for finding the typo!