### PR TITLE
fix UTF-8 cli args to exec

### DIFF
--- a/src/utils/execve.ts
+++ b/src/utils/execve.ts
@@ -94,10 +94,10 @@ export class CStringArray extends Uint8Array {
     let stringsLength = 0;
     for (const string of strings) {
       // Byte length of a UTF-8 string is never bigger than 3 times its length.
-      // 2 times the length would be a fairly safe guess. For command line arguments,
-      // we expect that all characters should be single-byte UTF-8 characters.
-      // Add one byte for the null byte.
-      stringsLength += string.length + 1;
+      // 2 times the length would be a fairly safe guess.
+      // This is slower than that, but should be safe, since it allocates the
+      // exact amount of memory needed.
+      stringsLength += ENCODER.encode(string).length + 1;
     }
     super(8 * (strings.length + 1) + stringsLength);
     const pointerBuffer = new BigUint64Array(this.buffer, 0, strings.length + 1);

--- a/tests/integration/tea.scripts.test.ts
+++ b/tests/integration/tea.scripts.test.ts
@@ -209,3 +209,20 @@ it(suite, "tea shebang but executed via tea interprets shebang", async function(
   const out = await this.run({args: [fixture.string]}).stdout()
   assertEquals(out.trim(), fuzz)
 })
+
+it(suite, "tea shebang handles UTF-8 args", async function() {
+  const fixture = this.sandbox.join("fixture.sh").write({ text: undent`
+    #!/usr/bin/env -S tea -E
+
+    /*---
+    args:
+      - deno
+      - run
+    ---*/
+
+    console.log(Deno.args)
+    `
+  }).chmod(0o500)
+  const out = await this.run({args: [fixture.string, '2∕2']}).stdout()
+  assertEquals(out.trim(), '[ "2∕2" ]')
+})


### PR DESCRIPTION
We need the actual buffer size, instead of string length. Slower, but otherwise we risk truncating input.

Example of failure in action: https://github.com/teaxyz/pantry/actions/runs/5506185252/jobs/10042047292

stage.ts is copying from a non-existent unpack directory, resulting in no source. see also the tarball ending in `tar.g`.