### PR TITLE
Update installaton methods in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,7 @@ If you prefer, tea is a standalone, cross-platform binary that you can install
 anywhere you want ([releases]). Here’s a handy one-liner:
 
 ```sh
-sudo install -m 755 \
-  <(curl --compressed -LSsf https://tea.xyz/$(uname)/$(uname -m)) \
-  /usr/local/bin/tea
+sh <(curl https://tea.xyz)
 ```
 
 ## Setting up Magic

--- a/README.md
+++ b/README.md
@@ -222,6 +222,14 @@ command not found: node
 
 # Getting Started
 
+The easiest way to install tea is with our installer:
+
+```sh
+sh <(curl https://tea.xyz)
+```
+
+You could also use Homebrew:
+
 ```sh
 brew install teaxyz/pkgs/tea-cli
 ```
@@ -230,7 +238,9 @@ If you prefer, tea is a standalone, cross-platform binary that you can install
 anywhere you want ([releases]). Here’s a handy one-liner:
 
 ```sh
-sh <(curl https://tea.xyz)
+sudo install -m 755 \\
+  <(curl --compressed -LSsf https://tea.xyz/$(uname)/$(uname -m)) \\
+  /usr/local/bin/tea
 ```
 
 ## Setting up Magic


### PR DESCRIPTION
The previous command did not work on a typical x86 Linux system. The link generated by the script - https://tea.xyz/Linux/x86_64 - was invalid. The updated command is taken directly from https://docs.tea.xyz/getting-started/install-tea