### PR TITLE
handles literal ~ in $PATH

### DIFF
--- a/src/utils/execve.ts
+++ b/src/utils/execve.ts
@@ -80,7 +80,13 @@ function find_in_PATH(cmd: string[], PATH?: string) {
   PATH ??= "/usr/bin:/bin"  // see manpage for execvp(3)
 
   for (const part of PATH.split(':')) {
-    const path = (part == '' || part == '.' ? Path.cwd() : new Path(part)).join(cmd[0])
+    const path = (() => {
+      if (part == '' || part == '.') return Path.cwd()
+      if (part == '~') return Path.home()
+      if (part.startsWith('~/')) return Path.home().join(part.slice(2))
+      //FIXME: not handled: ~user/...
+      return new Path(part)
+    })().join(cmd[0])
     if (path.isExecutableFile()) {
       cmd[0] = path.string
       return


### PR DESCRIPTION
closes #645

there's a `FIXME` for an edge case, but you'd have to be some kind of sicko pervert to have someone else's home directory in your `$PATH`.