### PR TITLE
allow .tea.yaml/yml per the docs

### DIFF
--- a/src/hooks/useVirtualEnv.ts
+++ b/src/hooks/useVirtualEnv.ts
@@ -256,7 +256,7 @@ export default async function(cwd: Path): Promise<VirtualEnv> {
     if (_if(".yarnrc.yml")) {
       pkgs.push({ project: "yarnpkg.com", constraint })
     }
-    if (_if("tea.yml", "tea.yaml")) {
+    if (_if("tea.yml", "tea.yaml", ".tea.yaml", ".tea.yml")) {
       insert(refineFrontMatter(await f!.readYAML()))
     }
     if (_if("VERSION")) {


### PR DESCRIPTION
closes #651

complies with: [Finally, you can just use tea.yaml (or .tea.yaml) if you like.](https://docs.tea.xyz/features/developer-environments).