### PR TITLE
Add `--sync` to gitpod and dev docs

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,5 +15,6 @@ tasks:
       (
         set -e
         .deno/bin/deno task compile
+        ./tea --sync
         echo "./tea is hot"
       )

--- a/README.md
+++ b/README.md
@@ -312,7 +312,8 @@ deno task run foo
 $ deno task install
 # ^^ deploys the local checkout into your `~/.tea`
 
-$ deno task compile && ./tea
+$ deno task compile && ./tea --sync
+# compile and run tea to sync package definitions
 ```
 
 


### PR DESCRIPTION
Otherwise, `./tea` fails with

    error: pantry not found: /home/gitpod/.tea/tea.xyz/var/pantry/projects