### PR TITLE
Fixing exit prompt formatting

### DIFF
--- a/src/app.exec.ts
+++ b/src/app.exec.ts
@@ -46,7 +46,7 @@ export async function repl(installations: Installation[], env: Record<string, st
   // python etc. have the same behavior
   console.error('this is a temporary shell containing the following packages:')
   console.error(pkgs_str())
-  console.error("when done type: `exit'")
+  console.error("when done type: `exit`")
 
   const shell = SHELL?.trim() || "/bin/sh"
   const cmd = [shell, '-i'] // interactive


### PR DESCRIPTION
Fixes: https://github.com/teaxyz/gui/issues/771

The consistent use of backticks matches what is present in the README (https://github.com/teaxyz/cli/blob/main/README.md?plain=1#L152)