### PR TITLE
Only read packages from action.yml that specifies version

### DIFF
--- a/src/hooks/useVirtualEnv.ts
+++ b/src/hooks/useVirtualEnv.ts
@@ -205,11 +205,13 @@ export default async function(cwd: Path): Promise<VirtualEnv> {
     }
     if (_if("action.yml", "action.yaml")) {
       const yaml = validate.obj(await f!.readYAML())
-      const [,v] = yaml.runs?.using.match(/node(\d+)/) ?? []
-      pkgs.push({
-        project: "nodejs.org",
-        constraint: new semver.Range(`^${v}`)
-      })
+      const match = yaml.runs?.using.match(/node(\d+)/)
+      if(match) {
+        pkgs.push({
+          project: "nodejs.org",
+          constraint: new semver.Range(`^${match[1]}`)
+        })
+      }
     }
     if (_if("cargo.toml")) {
       pkgs.push({project: "rust-lang.org", constraint})

--- a/tests/fixtures/no-version/action.yml
+++ b/tests/fixtures/no-version/action.yml
@@ -1,0 +1,2 @@
+runs:
+  using: docker

--- a/tests/functional/devenv.test.ts
+++ b/tests/functional/devenv.test.ts
@@ -145,6 +145,25 @@ Deno.test("should provide python in dev env", { sanitizeResources: false, saniti
   }
 })
 
+Deno.test("tolerant package parsing", { sanitizeResources: false, sanitizeOps: false }, async test => {
+  const SHELL = "/bin/zsh"
+
+  const tests = [
+    { file: "no-version/action.yml", pkg: [] },
+  ]
+
+  for (const {file, pkg} of tests) {
+    await test.step(file, async () => {
+      const {run, teaDir } = await createTestHarness()
+
+      fixturesDir.join(file).cp({into: teaDir})
+      const { stdout } = await run(["+tea.xyz/magic", "-Esk", "--chaste", "env"], { env: { SHELL, obj: {} } })
+
+      assertEquals(getTeaPackages(SHELL, stdout), pkg, "should match expected packages")
+    })
+  }
+})
+
 Deno.test("tolerant .node-version parsing", { sanitizeResources: false, sanitizeOps: false }, async test => {
   const SHELL = "/bin/zsh"
 


### PR DESCRIPTION
Took a stab at fixing #690 by only parsing `action.yml` version if version exists.

Closes #690