### PR TITLE
Run installed packages silently

### DIFF
--- a/src/modes/install.ts
+++ b/src/modes/install.ts
@@ -23,7 +23,7 @@ export default async function(pkgs: PackageRequirement[]) {
         const f = dst.join(program)
         f.write({ text: undent`
           #!/bin/sh
-          exec tea +${utils.pkg.str(pkg)} -- ${program} "$@"
+          exec tea --silent +${utils.pkg.str(pkg)} -- ${program} "$@"
           `}).chmod(0o755)
         console.error('tea: installed:', f)
         n++


### PR DESCRIPTION
I think this would be preferable to the otherwise intrusive logging that may break certain programs or GUIs that expect clean output from tools like e.g. git. And since we can't really install a package without resolving it first, it'd be rather rare for logging to be useful when executing installed packages which have already been resolved.